### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
+You can also run the setup script which creates a Python virtual environment
+and installs the dependencies automatically:
+
+```bash
+./scripts/setup.sh
+```
+
 ## Configuration
 
 1. Obtain a client secret JSON file from Google Cloud and place it in the project directory.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple setup script for gmail_automation
+# Creates a Python virtual environment and installs dependencies
+
+VENV_DIR=".venv"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    python3 -m venv "$VENV_DIR"
+    echo "Created virtual environment in $VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Setup complete. Activate the environment with 'source $VENV_DIR/bin/activate'"


### PR DESCRIPTION
## Summary
- add a `setup.sh` utility for creating a venv and installing requirements
- document usage of setup script in README

## Testing
- `python -m py_compile gmail_automation.py`

------
https://chatgpt.com/codex/tasks/task_e_68801b1ae338832f97e735694fd1d3af