### PR TITLE
Fix path for resolved issue archiving

### DIFF
--- a/.github/workflows/archive-resolved.yml
+++ b/.github/workflows/archive-resolved.yml
@@ -25,6 +25,7 @@ jobs:
           FILE=$(ls issues 2>/dev/null | grep -E "^${ISSUE_NUM}_" | head -n1 || true)
           if [ -z "$FILE" ]; then
             FILE=$(grep -irl "$ISSUE_TITLE" issues | head -n1 || true)
+            FILE="${FILE#issues/}"
           fi
           if [ -z "$FILE" ]; then
             echo "No matching file found" && exit 0


### PR DESCRIPTION
## Summary
- adjust the archive-resolved workflow to strip `issues/` prefix returned by `grep`

## Testing
- `python -m py_compile gmail_automation.py`

------
https://chatgpt.com/codex/tasks/task_e_688151e8cc28832f974f48365e71a3bc