### PR TITLE
Fix push permissions in archive workflow

### DIFF
--- a/.github/workflows/archive-resolved.yml
+++ b/.github/workflows/archive-resolved.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   archive:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -25,6 +27,7 @@ jobs:
           FILE=$(ls issues 2>/dev/null | grep -E "^${ISSUE_NUM}_" | head -n1 || true)
           if [ -z "$FILE" ]; then
             FILE=$(grep -irl "$ISSUE_TITLE" issues | head -n1 || true)
+            FILE="${FILE#issues/}"
           fi
           if [ -z "$FILE" ]; then
             echo "No matching file found" && exit 0
@@ -36,4 +39,4 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- ensure workflow token has write access to push archived issue files
- fallback to the builtin `GITHUB_TOKEN` if a personal access token isn't provided

## Testing
- `python -m py_compile gmail_automation.py`


------
https://chatgpt.com/codex/tasks/task_e_688151e8cc28832f974f48365e71a3bc