### PR TITLE
Add AGENTS.md guidelines across subdirectories

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,7 @@
+# GitHub Configuration Directory
+
+- Houses repository-wide configuration such as issue templates and workflows.
+- Keep YAML files well formatted and validate them with `pre-commit run --files <file>`.
+- Reference external actions with tagged versions rather than `@main`.
+- Avoid storing secrets; use encrypted repository or organization secrets.
+- When adding new workflows or templates, update documentation or README references.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,7 @@
+# GitHub Workflows Directory
+
+- Store GitHub Actions workflow `.yml` files.
+- Use descriptive file names with hyphens, e.g. `python-tests.yml`.
+- Pin actions to a specific commit or version.
+- Test workflow logic locally with `act` when possible.
+- Ensure new workflows run `pre-commit` and relevant tests.

--- a/.vscode/AGENTS.md
+++ b/.vscode/AGENTS.md
@@ -1,0 +1,7 @@
+# VS Code Settings Directory
+
+- Contains workspace configuration for VS Code.
+- Only include settings beneficial to the entire team.
+- Use JSON format; keep indentation at two spaces.
+- Document recommended extensions in `extensions.json`.
+- Avoid committing user- or machine-specific paths.

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,0 +1,7 @@
+# Configuration Directory
+
+- Holds project configuration templates and default settings.
+- Prefer TOML or YAML for structured configuration.
+- Never commit real credentials or secrets.
+- Update sample files and documentation when config schema changes.
+- Add comments to guide users on required values and formats.

--- a/config/config-sample/AGENTS.md
+++ b/config/config-sample/AGENTS.md
@@ -1,0 +1,7 @@
+# Sample Configuration Directory
+
+- Provides example configuration files for users.
+- Use placeholder values that cannot accidentally leak secrets.
+- Keep filenames consistent with their real counterparts using `.sample` suffix.
+- Include comments describing each option.
+- Validate that examples remain in sync with actual configuration options.

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -1,0 +1,7 @@
+# Data Directory
+
+- Store small datasets or fixtures used for development and tests.
+- Exclude large files (>5MB) and sensitive information via `.gitignore`.
+- Document data sources and licenses in a `README.md` when adding new files.
+- Prefer CSV or JSON formats for tabular or structured data.
+- Ensure deterministic data; avoid committing generated artifacts.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,7 @@
+# Documentation Directory
+
+- Maintain project documentation in Markdown.
+- Use `#`-style headings and wrap lines at ~80 characters.
+- Update docs alongside code changes; link to relevant modules or scripts.
+- Use relative links for cross-references within the repository.
+- Run `pre-commit run --files <doc>` to check formatting.

--- a/issues/solved/AGENTS.md
+++ b/issues/solved/AGENTS.md
@@ -1,0 +1,7 @@
+# Solved Issues Directory Guidelines
+
+- Archive resolved issues as Markdown files.
+- Name files with `NNN_issue-name.md` where NNN is the issue number.
+- Begin each file with a short summary and reference commit or PR numbers.
+- Group related attachments or assets in the same folder.
+- Do not modify archived issues except to fix typos.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,7 @@
+# Scripts Directory
+
+- Store utility and helper scripts.
+- Use lowercase, hyphen-separated filenames for shell scripts and snake_case for Python scripts.
+- Include a shebang and execute permission for runnable scripts.
+- Document expected arguments and environment variables in comments.
+- Prefer using `argparse` for Python scripts; run `shellcheck` on shell scripts.

--- a/scripts/dashboard/AGENTS.md
+++ b/scripts/dashboard/AGENTS.md
@@ -1,0 +1,7 @@
+# Dashboard Scripts Directory
+
+- Scripts supporting the dashboard feature.
+- Follow guidelines from `../AGENTS.md`.
+- Keep dependencies minimal and document required external services.
+- Place shared configuration in `config/` rather than hard-coding paths.
+- Provide example commands in comments for common tasks.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,7 @@
+# Source Code Directory
+
+- Contains application source code.
+- Follow PEP 8 and use type hints.
+- Include module and function docstrings describing behaviour and return types.
+- Write unit tests for new code in the `tests/` directory.
+- Avoid direct side effects at import time; use `if __name__ == "__main__":` for scripts.

--- a/src/gmail_automation/AGENTS.md
+++ b/src/gmail_automation/AGENTS.md
@@ -1,0 +1,7 @@
+# Gmail Automation Package
+
+- Core package modules live here.
+- Expose public APIs via `__all__` in `__init__.py` when appropriate.
+- Use logging instead of `print` statements.
+- Keep functions small and focused; factor out reusable components.
+- Ensure new modules are importable and covered by tests.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,7 @@
+# Tests Directory
+
+- Store unit and integration tests executed with `pytest`.
+- Name test files `test_*.py` and test functions `test_*`.
+- Use fixtures for reusable setup; place shared fixtures in `conftest.py`.
+- Avoid network calls and other flaky dependencies; use mocking where necessary.
+- Run `pytest` and `pre-commit run --files <test>` before committing.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,7 @@
+# Tools Directory
+
+- Auxiliary tools and scripts supporting development.
+- Provide usage examples in each tool's README or module docstring.
+- Ensure scripts run on macOS, Linux, and Windows where possible.
+- Keep third-party dependencies in `requirements.txt` or `pyproject.toml`.
+- Update documentation when adding or modifying tools.


### PR DESCRIPTION
## Summary
- Expand AGENTS.md files with detailed instructions for configuration, documentation, scripts, source code, and tests

## Testing
- `pre-commit run --files .github/AGENTS.md .github/workflows/AGENTS.md .vscode/AGENTS.md config/AGENTS.md config/config-sample/AGENTS.md data/AGENTS.md docs/AGENTS.md issues/solved/AGENTS.md scripts/AGENTS.md scripts/dashboard/AGENTS.md src/AGENTS.md src/gmail_automation/AGENTS.md tests/AGENTS.md tools/AGENTS.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'gmail_automation.cli'; 'gmail_automation' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a63bbf288c832fa29d51b0f2f0fc02