### PR TITLE
Restrict CI linting scope to src and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,17 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 src/ tests/ gmail_automation.py --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings
-          flake8 src/ tests/ gmail_automation.py --count --exit-zero --max-complexity=10 --statistics
+          flake8 src/ tests/ --count --exit-zero --max-complexity=10 --statistics
 
       - name: Check code formatting with black
         run: |
-          black --check --diff src/ tests/ gmail_automation.py
+          black --check --diff src/ tests/
 
       - name: Type check with mypy
         run: |
-          mypy src/ gmail_automation.py
+          mypy src/ tests/
         continue-on-error: true # Don't fail CI on mypy errors initially
 
       - name: Test with pytest


### PR DESCRIPTION
## Summary
- limit flake8, black, and mypy in CI to `src/` and `tests/`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'oauth2client')*

------
https://chatgpt.com/codex/tasks/task_e_68a945479be4832fabb39bb7435a72e7