### PR TITLE
Enable module execution without installation

### DIFF
--- a/gmail_automation/__init__.py
+++ b/gmail_automation/__init__.py
@@ -1,0 +1,27 @@
+"""Expose the actual package from ``src`` for direct execution.
+
+This wrapper allows running ``python -m gmail_automation`` without
+installing the project by loading the package from ``src/gmail_automation``
+at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+_pkg_init = (
+    Path(__file__).resolve().parent.parent / "src" / "gmail_automation" / "__init__.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    __name__,
+    _pkg_init,
+    submodule_search_locations=[str(_pkg_init.parent)],
+)
+if _spec is None or _spec.loader is None:  # pragma: no cover - defensive
+    raise ModuleNotFoundError("Cannot load package from src/gmail_automation")
+
+_module = importlib.util.module_from_spec(_spec)
+sys.modules[__name__] = _module
+_spec.loader.exec_module(_module)

--- a/tests/test_cli_entry_point.py
+++ b/tests/test_cli_entry_point.py
@@ -1,0 +1,18 @@
+"""Tests for the command line entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_module_executes_help() -> None:
+    """Ensure ``python -m gmail_automation --help`` runs successfully."""
+    result = subprocess.run(
+        [sys.executable, "-m", "gmail_automation", "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- allow `python -m gmail_automation` by dynamically loading package from `src`
- add test verifying command line help runs

## Testing
- `pre-commit run --files gmail_automation/__init__.py tests/test_cli_entry_point.py`
- `pytest`
- `python -m gmail_automation --help`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a50b17c832f87273fd878fa6594