### PR TITLE
Fix time import NameError in logging setup

### DIFF
--- a/src/gmail_automation/cli.py
+++ b/src/gmail_automation/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import sys
+import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Set, Tuple
 


### PR DESCRIPTION
## Summary
- import `time` to enable timezone conversion in logging

## Testing
- `pre-commit run --files src/gmail_automation/cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa529f7c74832f97fc6ef81178c493