### PR TITLE
Remove EMAIL_LIST configuration and dashboard features

### DIFF
--- a/config/config-sample/gmail_config.sample.json
+++ b/config/config-sample/gmail_config.sample.json
@@ -1,9 +1,6 @@
 {
     "EMAIL_USER": "you@example.com",
     "EMAIL_PASS": "app-specific-password",
-    "EMAIL_LIST": [
-        "sender@example.com"
-    ],
     "SENDER_TO_LABELS": {
         "Example_Label": [
             {

--- a/scripts/dashboard/AGENTS.md
+++ b/scripts/dashboard/AGENTS.md
@@ -40,7 +40,7 @@ This document describes the roles and responsibilities of the automated agents a
 - **Role**: UI definition.
 - **Responsibilities**:
   - Render main dashboard layout and tables.
-  - Provide editing controls for `EMAIL_LIST` and `SENDER_TO_LABELS`.
+  - Provide editing controls for `SENDER_TO_LABELS`.
   - Host report export buttons and table toggles.
 
 ### 5. `transforms.py`
@@ -55,7 +55,7 @@ This document describes the roles and responsibilities of the automated agents a
 - **Role**: Static and semantic analysis on config data.
 - **Responsibilities**:
   - Check alphabetization, case, and duplicates.
-  - Validate email consistency across `EMAIL_LIST` and `SENDER_TO_LABELS`.
+  - Validate SENDER_TO_LABELS entries for sorting, casing, and duplicates.
   - Compute diffs between current and expected label mappings.
 
 ### 7. `reports.py`

--- a/scripts/dashboard/TODO_dashboard.md
+++ b/scripts/dashboard/TODO_dashboard.md
@@ -50,10 +50,6 @@
 
 ## Medium-Priority
 
-### 🔲 Highlight Unlabeled Emails in UI
-
-- Show emails in `EMAIL_LIST` that have no label association.
-
 ### 🔲 Lint/Type Checks Pre-Commit
 
 - Add pre-commit hooks for `black`, `flake8`, `mypy`, etc.

--- a/scripts/dashboard/app.py
+++ b/scripts/dashboard/app.py
@@ -4,12 +4,11 @@ from .layout import make_layout
 from .callbacks import register_callbacks
 from .analysis import (
     load_config,
-    analyze_email_consistency,
     check_alphabetization,
     check_case_and_duplicates,
     compute_label_differences,
 )
-from .transforms import config_to_tables
+from .transforms import config_to_table
 from .utils_io import read_json
 from .constants import LABELS_JSON
 from .reports import write_ECAQ_report, write_diff_json
@@ -27,9 +26,8 @@ def _prepare_initial_data():
     except Exception:
         pass
 
-    el_rows, stl_rows = config_to_tables(cfg)
+    stl_rows = config_to_table(cfg)
     analysis = {
-        "consistency": analyze_email_consistency(cfg),
         "sorting": check_alphabetization(cfg),
         "case_dups": check_case_and_duplicates(cfg),
     }
@@ -37,14 +35,14 @@ def _prepare_initial_data():
     if LABELS_JSON.exists():
         labels = read_json(LABELS_JSON)
         diff = compute_label_differences(cfg, labels)
-    return cfg, el_rows, stl_rows, analysis, diff
+    return cfg, stl_rows, analysis, diff
 
 
 def main():
-    cfg, el_rows, stl_rows, analysis, diff = _prepare_initial_data()
+    cfg, stl_rows, analysis, diff = _prepare_initial_data()
     app = Dash(__name__)
     app.title = "Gmail Config Dashboard"
-    app.layout = make_layout(el_rows, stl_rows, analysis, diff, cfg)
+    app.layout = make_layout(stl_rows, analysis, diff, cfg)
     register_callbacks(app)
     app.run(host="127.0.0.1", port=8050, debug=False)
 

--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -1,7 +1,7 @@
 from dash import html, dcc, dash_table
 
 
-def make_layout(el_rows, stl_rows, analysis, diff, cfg):
+def make_layout(stl_rows, analysis, diff, cfg):
     section_style = {"marginBottom": "24px"}
     control_row = html.Div(
         style={"display": "flex", "gap": "12px", "flexWrap": "wrap"},
@@ -50,38 +50,6 @@ def make_layout(el_rows, stl_rows, analysis, diff, cfg):
                     html.Div(id="metrics", style={"marginBottom": "8px"}),
                     html.Div(id="issues-block", style={"marginBottom": "8px"}),
                     html.Div(id="projected-changes"),
-                ],
-            ),
-            html.Div(
-                style=section_style,
-                children=[
-                    html.H2("EMAIL_LIST Editor"),
-                    dash_table.DataTable(
-                        id="tbl-email-list",
-                        columns=[{"name": "email", "id": "email"}],
-                        data=el_rows,
-                        editable=True,
-                        row_deletable=True,
-                        row_selectable="multi",
-                        page_size=15,
-                        style_table={"maxHeight": "350px", "overflowY": "auto"},
-                        style_cell={"fontFamily": "monospace", "fontSize": "12px"},
-                    ),
-                    html.Div(
-                        style={"display": "flex", "alignItems": "center", "gap": "8px"},
-                        children=[
-                            html.Button(
-                                "Add blank row to EMAIL_LIST",
-                                id="btn-add-email-row",
-                                n_clicks=0,
-                                title="Append an empty row for a new email address",
-                            ),
-                            html.Span(
-                                "Appends an empty row to the table for a new email.",
-                                style={"fontSize": "12px", "color": "#555"},
-                            ),
-                        ],
-                    ),
                 ],
             ),
             html.Div(
@@ -141,7 +109,7 @@ def make_layout(el_rows, stl_rows, analysis, diff, cfg):
                                 n_clicks=0,
                                 style={"background": "#e8f0ff"},
                                 title=(
-                                    "Sync changes from both tables to the "
+                                    "Sync changes from the table to the "
                                     "working config. Use Save Config to "
                                     "write to file."
                                 ),
@@ -150,7 +118,7 @@ def make_layout(el_rows, stl_rows, analysis, diff, cfg):
                     ),
                     html.Span(
                         (
-                            "Applies edits from both tables to the working "
+                            "Applies edits from the table to the working "
                             "config; remember to Save Config to persist."
                         ),
                         style={"fontSize": "12px", "color": "#555"},

--- a/scripts/dashboard/reports.py
+++ b/scripts/dashboard/reports.py
@@ -6,7 +6,6 @@ from .constants import LABELS_JSON, REPORT_TXT, DIFF_JSON
 from .utils_io import read_json, write_json
 from .analysis import (
     load_config,
-    analyze_email_consistency,
     check_alphabetization,
     check_case_and_duplicates,
     compute_label_differences,
@@ -16,7 +15,6 @@ from .analysis import (
 
 
 def generate_report_text(cfg: dict) -> str:
-    cons = analyze_email_consistency(cfg)
     sort_issues = check_alphabetization(cfg)
     cd = check_case_and_duplicates(cfg)
 
@@ -33,34 +31,7 @@ def generate_report_text(cfg: dict) -> str:
         f"Generated: {ts}",
         "Target: config/gmail_config-final.json",
         "",
-        "CONSISTENCY SUMMARY:",
-        f"  EMAIL_LIST count: {cons['email_list_count']}",
-        f"  SENDER_TO_LABELS email set: {cons['sender_labels_count']}",
-        f"  Sets identical: {cons['are_identical']}",
-        "",
     ]
-    if cons["missing_in_sender"]:
-        lines += [
-            (
-                "EMAILS IN EMAIL_LIST BUT NOT IN SENDER_TO_LABELS "
-                f"({len(cons['missing_in_sender'])}):"
-            ),
-            "",
-        ]
-        lines += [f"- {e}" for e in cons["missing_in_sender"]]
-        lines.append("")
-    if cons["missing_in_list"]:
-        lines += [
-            (
-                "EMAILS IN SENDER_TO_LABELS BUT NOT IN EMAIL_LIST "
-                f"({len(cons['missing_in_list'])}):"
-            ),
-            "",
-        ]
-        for e in cons["missing_in_list"]:
-            labels = cons["email_to_labels"].get(e, ["Unknown"])
-            lines.append(f"- {e} (labels: {', '.join(labels)})")
-        lines.append("")
     if sort_issues:
         msg = f"LISTS NOT ALPHABETIZED ({len(sort_issues)}): "
         lines += [msg, ""]
@@ -80,16 +51,9 @@ def generate_report_text(cfg: dict) -> str:
             for d in i["duplicates"]:
                 lines.append(f"  • {d}")
         lines.append("")
-    all_good = (
-        cons["are_identical"]
-        and not sort_issues
-        and not cd["case_issues"]
-        and not cd["duplicate_issues"]
-    )
+    all_good = not sort_issues and not cd["case_issues"] and not cd["duplicate_issues"]
     if all_good:
-        lines.append(
-            "STATUS: CLEAN. All lists consistent, alphabetized, lowercase, unique."
-        )
+        lines.append("STATUS: CLEAN. All lists alphabetized, lowercase, unique.")
     else:
         lines += [
             "ISSUES FOUND - RECOMMENDATIONS:",


### PR DESCRIPTION
## Summary
- drop EMAIL_LIST from sample config and codebase
- simplify dashboard transforms, analysis, and layout for SENDER_TO_LABELS only
- streamline reporting and callbacks after removing email list

## Testing
- `pre-commit run --files config/config-sample/gmail_config.sample.json scripts/dashboard/transforms.py scripts/dashboard/analysis.py scripts/dashboard/layout.py scripts/dashboard/callbacks.py scripts/dashboard/app.py scripts/dashboard/reports.py scripts/dashboard/AGENTS.md scripts/dashboard/TODO_dashboard.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa56715884832f88b42c0710805a84