### PR TITLE
Include email date in deletion logs

### DIFF
--- a/src/gmail_automation/cli.py
+++ b/src/gmail_automation/cli.py
@@ -333,11 +333,12 @@ def process_email(
                 if days_diff >= delete_after_days:
                     logging.info(
                         (
-                            "Deleting email from '%s' with subject '%s' "
+                            "Deleting email from '%s' with subject '%s' dated '%s' "
                             "as it is older than %s days."
                         ),
                         sender,
                         subject,
+                        date,
                         delete_after_days,
                     )
                     if dry_run:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,29 +238,40 @@ class TestProcessEmail(unittest.TestCase):
             False,
         )
 
-        result = process_email(
-            service,
-            "me",
-            "123",
-            None,
-            None,
-            None,
-            None,
-            "Streaming",
-            True,
-            30,
-            {"Streaming": "label_id"},
-            set(),
-            set(),
-            {},
-            {},
-            dry_run=False,
-        )
+        with patch("logging.info") as mock_logging_info:
+            result = process_email(
+                service,
+                "me",
+                "123",
+                None,
+                None,
+                None,
+                None,
+                "Streaming",
+                True,
+                30,
+                {"Streaming": "label_id"},
+                set(),
+                set(),
+                {},
+                {},
+                dry_run=False,
+            )
 
         self.assertTrue(result)
         messages.get.assert_not_called()
         mock_modify.assert_not_called()
         messages.delete.assert_called_once_with(userId="me", id="123")
+        mock_logging_info.assert_any_call(
+            (
+                "Deleting email from '%s' with subject '%s' dated '%s' "
+                "as it is older than %s days."
+            ),
+            "sender@example.com",
+            "Old Subject",
+            "01/01/2000, 12:00 AM PST",
+            30,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log each deleted email's date in deletion message
- test deletion logging includes email date

## Testing
- `pre-commit run --files src/gmail_automation/cli.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab92b39ce8832f9deaad04a4310e9c