### PR TITLE
Fix data type inconsistencies in dashboard config

### DIFF
--- a/config/config-sample/gmail_config.sample.json
+++ b/config/config-sample/gmail_config.sample.json
@@ -4,7 +4,7 @@
     "SENDER_TO_LABELS": {
         "Example_Label": [
             {
-                "read_status": "true",
+                "read_status": true,
                 "delete_after_days": 30,
                 "emails": [
                     "sender@example.com"

--- a/tests/test_dashboard_transforms.py
+++ b/tests/test_dashboard_transforms.py
@@ -1,0 +1,61 @@
+from scripts.dashboard.transforms import config_to_table, table_to_config
+
+
+def test_config_to_table_sanitizes_types():
+    cfg = {
+        "SENDER_TO_LABELS": {
+            "Label": [
+                {
+                    "emails": ["a@example.com"],
+                    "read_status": "true",
+                    "delete_after_days": "30",
+                }
+            ]
+        }
+    }
+    rows = config_to_table(cfg)
+    assert rows == [
+        {
+            "label": "Label",
+            "group_index": 0,
+            "email": "a@example.com",
+            "read_status": True,
+            "delete_after_days": 30,
+        }
+    ]
+
+
+def test_table_to_config_sanitizes_types():
+    rows = [
+        {
+            "label": "Label",
+            "group_index": 0,
+            "email": "a@example.com",
+            "read_status": "true",
+            "delete_after_days": "30",
+        },
+        {
+            "label": "Label",
+            "group_index": 1,
+            "email": "b@example.com",
+            "read_status": "false",
+            "delete_after_days": None,
+        },
+    ]
+    cfg = table_to_config(rows)
+    assert cfg == {
+        "SENDER_TO_LABELS": {
+            "Label": [
+                {
+                    "read_status": True,
+                    "delete_after_days": 30,
+                    "emails": ["a@example.com"],
+                },
+                {
+                    "read_status": False,
+                    "delete_after_days": None,
+                    "emails": ["b@example.com"],
+                },
+            ]
+        }
+    }


### PR DESCRIPTION
## Summary
- add helper to coerce boolean and integer types in dashboard transforms
- ensure sample config uses boolean read_status
- test transforms sanitize types on import and export

## Testing
- `pre-commit run --files config/config-sample/gmail_config.sample.json scripts/dashboard/transforms.py tests/test_dashboard_transforms.py`
- `pytest`

Closes #93

------
https://chatgpt.com/codex/tasks/task_e_68acd5565ecc832f8a7d3b653b88d546