### PR TITLE
feat: add advanced group controls

### DIFF
--- a/scripts/dashboard/group_ops.py
+++ b/scripts/dashboard/group_ops.py
@@ -1,0 +1,63 @@
+"""Utilities for manipulating group indices in the dashboard table."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+
+def merge_selected(
+    rows: List[Dict[str, Any]], indices: List[int]
+) -> List[Dict[str, Any]]:
+    """Merge selected rows by label into the lowest ``group_index``.
+
+    Args:
+        rows: Current table rows.
+        indices: Positions of selected rows.
+
+    Returns:
+        A new list with updated ``group_index`` values.
+    """
+    result = [dict(r) for r in rows]
+    by_label: Dict[str, List[Tuple[int, int]]] = {}
+    for idx in indices:
+        row = result[idx]
+        label = row.get("label", "")
+        gi = row.get("group_index") or 0
+        by_label.setdefault(label, []).append((idx, gi))
+    for items in by_label.values():
+        min_gi = min(gi for _, gi in items)
+        for idx, _ in items:
+            result[idx]["group_index"] = min_gi
+    return result
+
+
+def split_selected(
+    rows: List[Dict[str, Any]], indices: List[int]
+) -> List[Dict[str, Any]]:
+    """Assign new ``group_index`` values to each selected row.
+
+    Each row is moved to a unique group after the current maximum index for
+    its label.
+
+    Args:
+        rows: Current table rows.
+        indices: Positions of selected rows.
+
+    Returns:
+        A new list with updated ``group_index`` values.
+    """
+    result = [dict(r) for r in rows]
+    max_gi: Dict[str, int] = {}
+    for row in result:
+        label = row.get("label", "")
+        gi = row.get("group_index") or 0
+        max_gi[label] = max(max_gi.get(label, -1), gi)
+    first_seen: Dict[str, bool] = {}
+    for idx in indices:
+        row = result[idx]
+        label = row.get("label", "")
+        if first_seen.get(label):
+            max_gi[label] += 1
+            row["group_index"] = max_gi[label]
+        else:
+            first_seen[label] = True
+    return result

--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -90,7 +90,11 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                                 "type": "numeric",
                             },
                         ],
-                        hidden_columns=["read_status", "delete_after_days"],
+                        hidden_columns=[
+                            "group_index",
+                            "read_status",
+                            "delete_after_days",
+                        ],
                         data=stl_rows,
                         editable=True,
                         row_deletable=True,
@@ -121,6 +125,15 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                                 ),
                             ),
                             html.Button(
+                                "Show Advanced Mode",
+                                id="btn-toggle-advanced",
+                                n_clicks=0,
+                                title=(
+                                    "Toggle visibility of grouping controls "
+                                    "and the group_index column"
+                                ),
+                            ),
+                            html.Button(
                                 "Apply table edits to config",
                                 id="btn-apply-edits",
                                 n_clicks=0,
@@ -130,6 +143,27 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                                     "working config. Use Save Config to "
                                     "write to file."
                                 ),
+                            ),
+                        ],
+                    ),
+                    html.Div(
+                        id="advanced-controls",
+                        style={"display": "none", "gap": "8px", "marginTop": "8px"},
+                        children=[
+                            html.Button(
+                                "Merge Selected",
+                                id="btn-merge-groups",
+                                n_clicks=0,
+                                title=(
+                                    "Merge selected rows into a single "
+                                    "group per label"
+                                ),
+                            ),
+                            html.Button(
+                                "Split Selected",
+                                id="btn-split-groups",
+                                n_clicks=0,
+                                title="Move each selected row into its own group",
                             ),
                         ],
                     ),

--- a/tests/test_dashboard_group_ops.py
+++ b/tests/test_dashboard_group_ops.py
@@ -1,0 +1,24 @@
+"""Tests for dashboard group operations."""
+from scripts.dashboard.group_ops import merge_selected, split_selected
+
+
+def test_merge_selected_merges_to_lowest_index():
+    rows = [
+        {"label": "A", "group_index": 0, "email": "a@example.com"},
+        {"label": "A", "group_index": 1, "email": "b@example.com"},
+        {"label": "B", "group_index": 0, "email": "c@example.com"},
+    ]
+    merged = merge_selected(rows, [0, 1])
+    assert merged[0]["group_index"] == 0
+    assert merged[1]["group_index"] == 0
+    assert merged[2]["group_index"] == 0
+
+
+def test_split_selected_assigns_unique_indices():
+    rows = [
+        {"label": "A", "group_index": 0, "email": "a@example.com"},
+        {"label": "A", "group_index": 0, "email": "b@example.com"},
+    ]
+    split = split_selected(rows, [0, 1])
+    indices = {r["group_index"] for r in split}
+    assert indices == {0, 1}


### PR DESCRIPTION
## Summary
- hide `group_index` by default and expose via Advanced Mode toggle
- allow merging or splitting selected rows into groups
- cover new group operations with tests

## Testing
- `pre-commit run --files scripts/dashboard/callbacks.py scripts/dashboard/layout.py scripts/dashboard/group_ops.py tests/test_dashboard_group_ops.py`
- `pytest`

Closes #104

------
https://chatgpt.com/codex/tasks/task_e_68afd7a2eff8832fa5037a3892293708