### PR TITLE
feat: highlight unprocessed senders in dashboard

### DIFF
--- a/scripts/dashboard/TODO_dashboard.md
+++ b/scripts/dashboard/TODO_dashboard.md
@@ -28,11 +28,11 @@
 - Normalize `delete_after_days` to `int` or `null`, not strings.
 - Add `_to_bool()` to `transforms.py` and sanitize on import/export.
 
-### 4. 🚩 Highlight “Unprocessed” Senders Visually
+### 4. 🚩 Highlight “Unprocessed” Senders Visually ✅
 
-- Add a red/yellow indicator next to emails with `last_run == DEFAULT_LAST_RUN_TIME`.
-- Let users filter, sort, or export the list.
-- Tooltip or explanation banner: “Not yet processed by Gmail automation.”
+- Pending senders table shows a red indicator for new emails.
+- Users can filter, sort, or export the list.
+- Added banner: “Not yet processed by Gmail automation.”
 
 ### 5. 🧩 Improve Group Index Visibility and Control
 

--- a/scripts/dashboard/analysis.py
+++ b/scripts/dashboard/analysis.py
@@ -35,8 +35,9 @@ def find_unprocessed_senders(cfg: dict) -> List[dict]:
         cfg: Loaded Gmail configuration.
 
     Returns:
-        List of dictionaries with ``email`` and associated ``labels`` for
-        senders whose last run time matches the default epoch.
+        List of dictionaries with ``email``, associated ``labels``, and a
+        ``status`` indicator for senders whose last run time matches the
+        default epoch.
     """
 
     all_emails, email_to_labels = extract_sender_to_labels_emails(cfg)
@@ -45,7 +46,11 @@ def find_unprocessed_senders(cfg: dict) -> List[dict]:
     for sender, ts in times.items():
         if ts == DEFAULT_LAST_RUN_TIME:
             pending.append(
-                {"email": sender, "labels": ", ".join(email_to_labels.get(sender, []))}
+                {
+                    "email": sender,
+                    "labels": ", ".join(email_to_labels.get(sender, [])),
+                    "status": "🔴",
+                }
             )
     return sorted(pending, key=lambda r: r["email"])
 

--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -56,9 +56,19 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                 style=section_style,
                 children=[
                     html.H2("New Senders Pending Processing"),
+                    html.Div(
+                        "Not yet processed by Gmail automation.",
+                        id="pending-help",
+                        style={
+                            "fontSize": "12px",
+                            "color": "#a00",
+                            "marginBottom": "4px",
+                        },
+                    ),
                     dash_table.DataTable(
                         id="tbl-new-senders",
                         columns=[
+                            {"name": "", "id": "status"},
                             {"name": "email", "id": "email"},
                             {"name": "labels", "id": "labels"},
                         ],
@@ -66,6 +76,21 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                         page_size=15,
                         style_table={"maxHeight": "200px", "overflowY": "auto"},
                         style_cell={"fontFamily": "monospace", "fontSize": "12px"},
+                        sort_action="native",
+                        filter_action="native",
+                        export_format="csv",
+                        export_headers="display",
+                        style_data_conditional=[
+                            {
+                                "if": {"filter_query": "{status} = '🔴'"},
+                                "backgroundColor": "#ffe5e5",
+                            },
+                            {
+                                "if": {"column_id": "status"},
+                                "textAlign": "center",
+                                "width": "30px",
+                            },
+                        ],
                     ),
                 ],
             ),

--- a/tests/test_dashboard_new_senders.py
+++ b/tests/test_dashboard_new_senders.py
@@ -22,4 +22,4 @@ def test_find_unprocessed_senders(monkeypatch):
     )
 
     result = analysis.find_unprocessed_senders(cfg)
-    assert result == [{"email": "new@example.com", "labels": "LabelA"}]
+    assert result == [{"email": "new@example.com", "labels": "LabelA", "status": "🔴"}]


### PR DESCRIPTION
## Summary
- add red status indicator and sorting/filtering to pending senders table
- document completion of unprocessed sender highlighting

## Testing
- `pre-commit run --files scripts/dashboard/analysis.py scripts/dashboard/layout.py scripts/dashboard/TODO_dashboard.md tests/test_dashboard_new_senders.py`
- `pytest`

Closes #102

------
https://chatgpt.com/codex/tasks/task_e_68b03ada80d0832f951f412cb8a1f168