### PR TITLE
feat(dashboard): persist log viewer selection

### DIFF
--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -339,5 +339,6 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
             dcc.Store(id="store-diff", data=diff),
             dcc.Store(id="store-pending", data=pending),
             dcc.Store(id="store-log-runs"),
+            dcc.Store(id="store-log-selection", storage_type="local"),
         ],
     )


### PR DESCRIPTION
## Summary
- persist selected log file and run using local storage
- restore log dropdowns and content from previous session

## Testing
- `pre-commit run --files scripts/dashboard/layout.py scripts/dashboard/callbacks.py`
- `pytest`

Closes #97

------
https://chatgpt.com/codex/tasks/task_e_68b3e7b806e4832f9bef5030463fe957