### PR TITLE
feat: add hoverable diff projections

### DIFF
--- a/tests/test_group_changes_by_label.py
+++ b/tests/test_group_changes_by_label.py
@@ -1,0 +1,17 @@
+from scripts.dashboard.callbacks import _group_changes_by_label
+
+
+def test_group_changes_by_label_groups_strings():
+    changes = [
+        "SENDER_TO_LABELS.Work[0].emails (fixed case)",
+        "SENDER_TO_LABELS.Work[1].emails (removed 2 duplicates)",
+        "SENDER_TO_LABELS.Personal[0].emails",
+        "Unrelated entry",
+    ]
+    grouped = _group_changes_by_label(changes)
+    assert grouped["Work"] == [
+        "SENDER_TO_LABELS.Work[0].emails (fixed case)",
+        "SENDER_TO_LABELS.Work[1].emails (removed 2 duplicates)",
+    ]
+    assert grouped["Personal"] == ["SENDER_TO_LABELS.Personal[0].emails"]
+    assert grouped["Unknown"] == ["Unrelated entry"]


### PR DESCRIPTION
## Summary
- group projected change messages by label
- show per-label hoverable details in projected change and diff summaries
- add unit test for change grouping

## Testing
- `pre-commit run --files scripts/dashboard/callbacks.py tests/test_group_changes_by_label.py`
- `pytest`

Closes #107

------
https://chatgpt.com/codex/tasks/task_e_68b3e729f778832fb71ac10473b17318