### PR TITLE
feat: add import validator for CSV and JSON

### DIFF
--- a/.codex/tasks/105_add_import_validator_for_external_files.yaml
+++ b/.codex/tasks/105_add_import_validator_for_external_files.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-issue-forms.json
+name: "Task 105: Add Import Validator for External Files"
+description: "Allow importing CSV or JSON files with schema validation"
+title: "[Task 105] Add Import Validator for External Files"
+labels:
+  - dashboard
+  - ux
+  - "priority: Medium"
+  - "status: in-progress"
+  - "task:105"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Summary
+        Users can upload external CSV or JSON files and receive validation
+        feedback before data is imported into the dashboard.
+  - type: markdown
+    attributes:
+      value: |
+        ## Details
+        Implement a reusable validator that parses uploaded files and ensures
+        required fields are present. Support JSON lists of objects and CSV with
+        headers.
+  - type: checkboxes
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Validator supports CSV and JSON uploads"
+        - label: "Missing fields produce human-readable errors"
+        - label: "Unit tests cover valid and invalid scenarios"
+  - type: markdown
+    attributes:
+      value: |
+        ## Plan
+        - Add `validate_import_file` utility
+        - Write tests exercising success and failure cases
+        - Integrate utility into dashboard upload flow (future work)
+  - type: markdown
+    attributes:
+      value: |
+        ## References
+        - scripts/dashboard/utils_io.py
+        - tests/test_dashboard_import_validator.py
+        - scripts/dashboard/TODO_dashboard.md

--- a/scripts/dashboard/utils_io.py
+++ b/scripts/dashboard/utils_io.py
@@ -1,7 +1,9 @@
+import csv
 import json
 from datetime import datetime
+from io import StringIO
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict, List, Tuple, cast
 
 
 def read_json(p: Path) -> Dict[str, Any]:
@@ -21,3 +23,54 @@ def backup_file(p: Path) -> Path:
     bkp.parent.mkdir(parents=True, exist_ok=True)
     bkp.write_bytes(p.read_bytes())
     return bkp
+
+
+def validate_import_file(contents: str, filename: str) -> Tuple[bool, List[str]]:
+    """Validate uploaded CSV or JSON file contents.
+
+    Parameters
+    ----------
+    contents:
+        Raw file contents decoded as a string.
+    filename:
+        Name of the uploaded file used to infer its extension.
+
+    Returns
+    -------
+    Tuple[bool, List[str]]
+        ``(is_valid, errors)`` where ``is_valid`` indicates whether the file
+        matches the expected schema and ``errors`` contains any validation
+        issues to surface to the user.
+    """
+
+    required_fields = {"sender", "labels"}
+    errors: List[str] = []
+    ext = Path(filename).suffix.lower()
+
+    try:
+        if ext == ".json":
+            data = json.loads(contents)
+            if not isinstance(data, list):
+                errors.append("JSON must be a list of objects")
+            else:
+                for idx, item in enumerate(data):
+                    if not isinstance(item, dict):
+                        errors.append(f"Item {idx} is not an object")
+                        continue
+                    missing = required_fields - item.keys()
+                    if missing:
+                        missing_str = ", ".join(sorted(missing))
+                        errors.append(f"Item {idx} missing fields: {missing_str}")
+        elif ext == ".csv":
+            reader = csv.DictReader(StringIO(contents))
+            header = set(reader.fieldnames or [])
+            missing = required_fields - header
+            if missing:
+                missing_str = ", ".join(sorted(missing))
+                errors.append(f"Missing columns: {missing_str}")
+        else:
+            errors.append("Unsupported file type")
+    except Exception as exc:  # pragma: no cover - unexpected parsing issues
+        errors.append(f"Failed to parse file: {exc}")
+
+    return (not errors, errors)

--- a/tests/test_dashboard_import_validator.py
+++ b/tests/test_dashboard_import_validator.py
@@ -1,0 +1,29 @@
+from scripts.dashboard.utils_io import validate_import_file
+
+
+def test_validate_import_file_valid_json():
+    contents = '[{"sender": "foo", "labels": ["bar"]}]'
+    is_valid, errors = validate_import_file(contents, "data.json")
+    assert is_valid is True
+    assert errors == []
+
+
+def test_validate_import_file_invalid_json_missing_fields():
+    contents = '[{"sender": "foo"}]'
+    is_valid, errors = validate_import_file(contents, "data.json")
+    assert is_valid is False
+    assert any("missing fields" in e.lower() for e in errors)
+
+
+def test_validate_import_file_valid_csv():
+    contents = "sender,labels\nfoo,bar\n"
+    is_valid, errors = validate_import_file(contents, "data.csv")
+    assert is_valid is True
+    assert errors == []
+
+
+def test_validate_import_file_invalid_csv_missing_column():
+    contents = "sender\nfoo\n"
+    is_valid, errors = validate_import_file(contents, "data.csv")
+    assert is_valid is False
+    assert any("missing columns" in e.lower() for e in errors)


### PR DESCRIPTION
## Summary
- add utility to validate CSV or JSON imports
- test validator against valid and invalid uploads
- track task for import validator work

## Testing
- `pre-commit run --files scripts/dashboard/utils_io.py tests/test_dashboard_import_validator.py .codex/tasks/105_add_import_validator_for_external_files.yaml`
- `pytest`

Closes #105

------
https://chatgpt.com/codex/tasks/task_e_68b3e80c4440832f819f8db3110758a1