### PR TITLE
Add package compatibility check to maintenance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ python -m scripts.maintenance --run-hooks
 # Run the test suite
 python -m scripts.maintenance --tests
 
+# Check for dependency conflicts
+python -m scripts.maintenance --check-compat
+
 # List outdated packages and choose to upgrade all/some interactively
 python -m scripts.maintenance --outdated
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,3 +36,8 @@ Outdated package maintenance:
   - `python -m scripts.maintenance --outdated --upgrade pandas plotly`
 - List only (no prompt, no upgrades):
   - `python -m scripts.maintenance --outdated --no-input`
+
+Compatibility checks:
+
+- Verify installed packages have compatible dependencies:
+  - `python -m scripts.maintenance --check-compat`


### PR DESCRIPTION
## Summary
- add `check_package_compatibility` using `pip check`
- expose `--check-compat` flag and run check after upgrades
- document compatibility checks in READMEs

## Testing
- `pre-commit run --files scripts/maintenance.py README.md scripts/README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3f969dc90832f88dddc992b806cf2