### PR TITLE
Add issue templates for dashboard improvements and logging

### DIFF
--- a/issues/_expand_logging_coverage.md
+++ b/issues/_expand_logging_coverage.md
@@ -1,0 +1,6 @@
+# Expand logging across helpers and scripts
+
+- Expand logging coverage across all helper, support, and script components to improve troubleshooting and observability.
+
+**Priority**: Medium
+**Labels**: enhancement, logging, general

--- a/issues/_expandable_grouped_tree.md
+++ b/issues/_expandable_grouped_tree.md
@@ -1,0 +1,8 @@
+# Expandable labels in Grouped Tree view
+
+These changes are to be implemented in the Dash dashboard.
+
+- Refactor the **Grouped Tree** view so each label can be expanded to reveal its emails.
+
+**Priority**: High
+**Labels**: dashboard, enhancement

--- a/issues/_fix_remove_button.md
+++ b/issues/_fix_remove_button.md
@@ -1,0 +1,8 @@
+# Fix Remove button in Grouped Tree view
+
+These changes are to be implemented in the Dash dashboard.
+
+- Ensure the **Remove** button in the **Grouped Tree** view detaches the selected email from its label.
+
+**Priority**: High
+**Labels**: dashboard, bug

--- a/issues/_grouped_tree_differences_view.md
+++ b/issues/_grouped_tree_differences_view.md
@@ -1,0 +1,8 @@
+# Create Grouped Tree version of Differences View
+
+These changes are to be implemented in the Dash dashboard.
+
+- Add an alternative **Grouped Tree** visualization for the **Differences View**.
+
+**Priority**: Low
+**Labels**: dashboard, feature

--- a/issues/_highlight_unprocessed_senders.md
+++ b/issues/_highlight_unprocessed_senders.md
@@ -1,0 +1,8 @@
+# Highlight unprocessed senders in New Senders section
+
+These changes are to be implemented in the Dash dashboard.
+
+- Make the text "Senders not yet processed by Gmail automation." more prominent beneath the main section title in **New Senders Pending Processing**.
+
+**Priority**: Medium
+**Labels**: dashboard, ux

--- a/issues/_label_filter_in_editor.md
+++ b/issues/_label_filter_in_editor.md
@@ -1,0 +1,8 @@
+# Add label filter to SENDER_TO_LABELS editor
+
+These changes are to be implemented in the Dash dashboard.
+
+- Add a label drop-down filter positioned below the **Differences View** in the **SENDER_TO_LABELS Editor**.
+
+**Priority**: Medium
+**Labels**: dashboard, feature

--- a/issues/_manage_ignored_emails.md
+++ b/issues/_manage_ignored_emails.md
@@ -1,0 +1,8 @@
+# Dedicated IGNORED_EMAILS management section
+
+These changes are to be implemented in the Dash dashboard.
+
+- Add a dedicated section for managing entries in **IGNORED_EMAILS**.
+
+**Priority**: High
+**Labels**: dashboard, feature

--- a/issues/_preserve_import_settings.md
+++ b/issues/_preserve_import_settings.md
@@ -1,0 +1,8 @@
+# Preserve read/delete settings in Import Missing
+
+These changes are to be implemented in the Dash dashboard.
+
+- Update **Import Missing** within the **Differences View** so it respects existing `read_status` and `delete_after_days` values instead of defaulting to `false` and `30`.
+
+**Priority**: Medium
+**Labels**: dashboard, enhancement

--- a/issues/_remove_filter_row.md
+++ b/issues/_remove_filter_row.md
@@ -1,0 +1,8 @@
+# Remove filter row from New Senders table
+
+These changes are to be implemented in the Dash dashboard.
+
+- Remove the "filter data" row from **New Senders Pending Processing**, while retaining the ability to sort columns.
+
+**Priority**: Medium
+**Labels**: dashboard, ux


### PR DESCRIPTION
## Summary
- document dashboard improvements like highlighting unprocessed senders, table cleanup, and label filtering
- log tasks for grouped tree enhancements and IGNORED_EMAILS management
- track expanding logging coverage across helpers and scripts
- rename issue files to remove numeric prefixes while keeping underscore prefix

## Testing
- `pre-commit run --files issues/_highlight_unprocessed_senders.md issues/_remove_filter_row.md issues/_label_filter_in_editor.md issues/_expandable_grouped_tree.md issues/_fix_remove_button.md issues/_grouped_tree_differences_view.md issues/_preserve_import_settings.md issues/_manage_ignored_emails.md issues/_expand_logging_coverage.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66971842c832f8a19abd8c7e6cdcf