### PR TITLE
Enhance ignored email rule processing

### DIFF
--- a/config/config-sample/gmail_config.sample.json
+++ b/config/config-sample/gmail_config.sample.json
@@ -11,5 +11,24 @@
                 ]
             }
         ]
-    }
+    },
+    "IGNORED_EMAILS": [
+        {
+            "name": "Example ignore",
+            "senders": [
+                "ignore@example.com"
+            ],
+            "subject_contains": [],
+            "actions": {
+                "skip_analysis": true,
+                "skip_import": true,
+                "mark_as_read": true,
+                "apply_labels": [
+                    "Ignored"
+                ],
+                "archive": true,
+                "delete_after_days": 0
+            }
+        }
+    ]
 }

--- a/docs/configuration_examples.md
+++ b/docs/configuration_examples.md
@@ -41,3 +41,35 @@ The automation normalizes string values such as `"true"`/`"false"` for
 `read_status` and converts `delete_after_days` to integers. Labels referenced in
 `SENDER_TO_LABELS` must already exist in Gmail; create them before running the
 script or through the dashboard.
+
+## Ignored email rules
+
+Use the optional `IGNORED_EMAILS` section to define deterministic actions that
+run before the standard labeling workflow. Each rule supports matching by sender
+or domain along with a set of actions.
+
+```json
+{
+  "IGNORED_EMAILS": [
+    {
+      "name": "Ignore alerts",
+      "senders": ["alerts@example.com"],
+      "actions": {
+        "skip_analysis": true,
+        "skip_import": true,
+        "mark_as_read": true,
+        "apply_labels": ["Ignored"],
+        "archive": true,
+        "delete_after_days": 0
+      }
+    }
+  ]
+}
+```
+
+- `skip_analysis` excludes matching addresses from dashboard comparisons.
+- `skip_import` prevents `Import missing` from adding the address back into the
+  config.
+- `mark_as_read`, `apply_labels`, `archive`, and `delete_after_days` control how
+  matching messages are handled in Gmail. Setting `delete_after_days` to `0`
+  deletes matching mail immediately after the rule runs.

--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -3,6 +3,7 @@
 from dash import dcc, dash_table, html
 
 from .theme import get_theme_style
+from .transforms import ignored_rules_to_rows
 
 
 def make_layout(stl_rows, analysis, diff, cfg, pending):
@@ -368,6 +369,71 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                         id="grouped-view",
                         style={"display": "none"},
                         children=[html.Div(id="stl-grouped")],
+                    ),
+                ],
+            ),
+            html.Div(
+                style=section_style,
+                children=[
+                    html.H2("Ignored Email Rules"),
+                    html.P(
+                        (
+                            "Rules processed in order before labeling. "
+                            "Use them to skip analysis/import and perform actions "
+                            "like marking as read or deleting."
+                        ),
+                        style={"fontSize": "14px", "maxWidth": "800px"},
+                    ),
+                    dash_table.DataTable(
+                        id="tbl-ignored",
+                        columns=[
+                            {"name": "name", "id": "name"},
+                            {"name": "senders", "id": "senders"},
+                            {"name": "domains", "id": "domains"},
+                            {"name": "subject_contains", "id": "subject_contains"},
+                            {"name": "skip_analysis", "id": "skip_analysis"},
+                            {"name": "skip_import", "id": "skip_import"},
+                            {"name": "mark_as_read", "id": "mark_as_read"},
+                            {"name": "apply_labels", "id": "apply_labels"},
+                            {"name": "archive", "id": "archive"},
+                            {
+                                "name": "delete_after_days",
+                                "id": "delete_after_days",
+                                "type": "numeric",
+                            },
+                        ],
+                        data=ignored_rules_to_rows(cfg),
+                        editable=True,
+                        row_deletable=True,
+                        page_size=10,
+                        style_table={"maxHeight": "300px", "overflowY": "auto"},
+                        style_cell={
+                            "fontFamily": "monospace",
+                            "fontSize": "12px",
+                            "whiteSpace": "normal",
+                        },
+                    ),
+                    html.Div(
+                        style={"display": "flex", "gap": "8px", "marginTop": "8px"},
+                        children=[
+                            html.Button(
+                                "Add ignored rule",
+                                id="btn-add-ignored-row",
+                                n_clicks=0,
+                                title="Append an empty ignored-email rule row",
+                            ),
+                            html.Button(
+                                "Apply IGNORED_EMAILS edits",
+                                id="btn-apply-ignored",
+                                n_clicks=0,
+                                style={"background": "#e8f0ff"},
+                                title=(
+                                    "Sync ignored-email table changes "
+                                    "to the working config. "
+                                    "Use Save Config to persist to disk."
+                                ),
+                            ),
+                        ],
                     ),
                 ],
             ),

--- a/src/gmail_automation/ignored_rules.py
+++ b/src/gmail_automation/ignored_rules.py
@@ -1,0 +1,383 @@
+"""Utilities for working with IGNORED_EMAILS configuration rules.
+
+This module defines a structured representation for ignore rules along with
+helpers to normalise configuration data and evaluate rule matches. The richer
+rule schema enables deterministic processing in the email pipeline and shared
+behaviour across analytics tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from email.utils import parseaddr
+from typing import Any, Dict, Iterable, Iterator, List, Sequence
+
+
+def _unique_preserve_order(values: Iterable[str]) -> List[str]:
+    """Return values with duplicates removed while preserving order."""
+
+    seen: set[str] = set()
+    result: List[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _to_bool(value: object, default: bool = False) -> bool:
+    """Coerce strings commonly used in configs to booleans."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y"}:
+            return True
+        if lowered in {"false", "0", "no", "n"}:
+            return False
+    return default
+
+
+def _clean_domain(value: str) -> str:
+    """Normalise a domain string by stripping whitespace and leading '@'."""
+
+    cleaned = value.strip()
+    if cleaned.startswith("@"):
+        cleaned = cleaned[1:]
+    return cleaned.lower()
+
+
+def _normalise_string_list(value: object) -> List[str]:
+    """Coerce list-like config values into a list of non-empty strings."""
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, Sequence):
+        return []
+    strings: List[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            strings.append(text)
+    return strings
+
+
+def _normalise_apply_labels(value: object) -> List[str]:
+    """Return a list of label names suitable for API usage."""
+
+    labels = _normalise_string_list(value)
+    return [label for label in labels if label]
+
+
+@dataclass(frozen=True)
+class RuleActions:
+    """Actions supported by an ignored-email rule."""
+
+    skip_analysis: bool = False
+    skip_import: bool = False
+    mark_as_read: bool = False
+    apply_labels: tuple[str, ...] = ()
+    archive: bool = False
+    delete_after_days: int | None = None
+
+    def has_pipeline_actions(self) -> bool:
+        """Return ``True`` if any actions affect the Gmail pipeline."""
+
+        return bool(
+            self.mark_as_read
+            or self.apply_labels
+            or self.archive
+            or self.delete_after_days is not None
+        )
+
+
+@dataclass(frozen=True)
+class IgnoredRule:
+    """Represent a single IGNORED_EMAILS rule."""
+
+    name: str
+    senders: tuple[str, ...]
+    domains: tuple[str, ...]
+    subject_contains: tuple[str, ...]
+    actions: RuleActions
+    index: int = field(default=0)
+    _senders_cf: tuple[str, ...] = field(init=False, repr=False)
+    _domains_cf: tuple[str, ...] = field(init=False, repr=False)
+    _subjects_cf: tuple[str, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass init code
+        object.__setattr__(
+            self, "_senders_cf", tuple(sender.casefold() for sender in self.senders)
+        )
+        object.__setattr__(
+            self,
+            "_domains_cf",
+            tuple(_clean_domain(domain) for domain in self.domains),
+        )
+        object.__setattr__(
+            self,
+            "_subjects_cf",
+            tuple(subject.casefold() for subject in self.subject_contains),
+        )
+
+    @staticmethod
+    def _extract_address(sender: str | None) -> str | None:
+        """Return the email address portion of a ``From`` header."""
+
+        if not sender:
+            return None
+        _name, addr = parseaddr(sender)
+        addr = addr.strip()
+        return addr or None
+
+    def matches_sender(self, sender: str | None) -> bool:
+        """Return ``True`` if the sender matches rule senders or domains."""
+
+        address = self._extract_address(sender)
+        if not address:
+            return False
+        folded = address.casefold()
+        if self._senders_cf and folded in self._senders_cf:
+            return True
+        if self._domains_cf:
+            domain = address.split("@", 1)[-1].casefold()
+            if domain in self._domains_cf:
+                return True
+        return False
+
+    def matches_subject(self, subject: str | None) -> bool:
+        """Return ``True`` if the subject matches configured substrings."""
+
+        if not self._subjects_cf:
+            return False
+        if subject is None:
+            return False
+        folded = subject.casefold()
+        return any(token in folded for token in self._subjects_cf)
+
+    def matches(self, sender: str | None, subject: str | None) -> bool:
+        """Return ``True`` if either sender or subject matches the rule."""
+
+        return self.matches_sender(sender) or self.matches_subject(subject)
+
+    def matches_address(self, address: str) -> bool:
+        """Case-insensitive match against a plain email address."""
+
+        folded = address.casefold()
+        if self._senders_cf and folded in self._senders_cf:
+            return True
+        if self._domains_cf:
+            domain = folded.split("@", 1)[-1]
+            return domain in self._domains_cf
+        return False
+
+
+class IgnoredRulesEngine:
+    """Evaluate IGNORED_EMAILS rules against messages."""
+
+    def __init__(self, rules: Sequence[IgnoredRule]):
+        self._rules = list(rules)
+
+    @classmethod
+    def from_config(cls, rules_config: Sequence[dict]) -> "IgnoredRulesEngine":
+        """Build an engine from normalised rule dictionaries."""
+
+        rules: List[IgnoredRule] = []
+        for index, data in enumerate(rules_config):
+            actions_dict = data.get("actions", {})
+            actions = RuleActions(
+                skip_analysis=_to_bool(actions_dict.get("skip_analysis")),
+                skip_import=_to_bool(actions_dict.get("skip_import")),
+                mark_as_read=_to_bool(actions_dict.get("mark_as_read")),
+                apply_labels=tuple(actions_dict.get("apply_labels", [])),
+                archive=_to_bool(actions_dict.get("archive")),
+                delete_after_days=actions_dict.get("delete_after_days"),
+            )
+            rules.append(
+                IgnoredRule(
+                    name=str(data.get("name", f"Rule {index + 1}")),
+                    senders=tuple(data.get("senders", [])),
+                    domains=tuple(data.get("domains", [])),
+                    subject_contains=tuple(data.get("subject_contains", [])),
+                    actions=actions,
+                    index=index,
+                )
+            )
+        return cls(rules)
+
+    @property
+    def rules(self) -> Sequence[IgnoredRule]:
+        """Return the ordered rule list."""
+
+        return tuple(self._rules)
+
+    def iter_matches(
+        self, sender: str | None, subject: str | None
+    ) -> Iterator[IgnoredRule]:
+        """Yield rules that match the provided sender or subject."""
+
+        for rule in self._rules:
+            if rule.matches(sender, subject):
+                yield rule
+
+    def should_skip_analysis(self, email: str) -> bool:
+        """Return ``True`` if any rule skips analysis for the email."""
+
+        folded = email.strip()
+        if not folded:
+            return False
+        for rule in self._rules:
+            if rule.actions.skip_analysis and rule.matches_address(folded):
+                return True
+        return False
+
+    def should_skip_import(self, email: str) -> bool:
+        """Return ``True`` if any rule skips config import for the email."""
+
+        folded = email.strip()
+        if not folded:
+            return False
+        for rule in self._rules:
+            if rule.actions.skip_import and rule.matches_address(folded):
+                return True
+        return False
+
+
+def normalize_ignored_rules(rules: Sequence[object]) -> List[dict]:
+    """Return canonical representations of IGNORED_EMAILS rules."""
+
+    normalized: List[dict] = []
+    for index, raw_rule in enumerate(rules or []):
+        normalized.append(_normalize_single_rule(raw_rule, index))
+    return normalized
+
+
+def _normalize_single_rule(raw_rule: object, index: int) -> dict:
+    if isinstance(raw_rule, str):
+        sender = raw_rule.strip()
+        if not sender:
+            raise ValueError("IGNORED_EMAILS entries cannot be empty strings")
+        return {
+            "name": sender,
+            "senders": [sender],
+            "domains": [],
+            "subject_contains": [],
+            "actions": {
+                "skip_analysis": True,
+                "skip_import": True,
+                "mark_as_read": False,
+                "apply_labels": [],
+                "archive": False,
+                "delete_after_days": None,
+            },
+        }
+
+    if not isinstance(raw_rule, dict):
+        raise ValueError(
+            "IGNORED_EMAILS entries must be strings or dictionaries; "
+            f"received type {type(raw_rule).__name__} at index {index}"
+        )
+
+    data: Dict[str, Any] = dict(raw_rule)  # shallow copy
+    match_raw = data.get("match")
+    match_section: Dict[str, Any]
+    if isinstance(match_raw, dict):
+        match_section = match_raw
+    else:
+        match_section = {}
+
+    senders = _normalise_string_list(
+        data.get("senders")
+        or data.get("emails")
+        or match_section.get("senders")
+        or match_section.get("emails")
+    )
+    domains = [
+        _clean_domain(d)
+        for d in _normalise_string_list(
+            data.get("domains")
+            or match_section.get("domains")
+            or data.get("domain")
+            or match_section.get("domain")
+        )
+    ]
+    subjects = _normalise_string_list(
+        data.get("subject_contains")
+        or match_section.get("subject_contains")
+        or data.get("subjects")
+        or match_section.get("subjects")
+    )
+
+    senders = _unique_preserve_order(senders)
+    domains = _unique_preserve_order(domain for domain in domains if domain)
+    subjects = _unique_preserve_order(subjects)
+
+    if not (senders or domains or subjects):
+        raise ValueError(
+            "IGNORED_EMAILS rules must define senders, domains, or subject filters"
+        )
+
+    actions_src = data.get("actions")
+    actions_dict: Dict[str, Any]
+    if isinstance(actions_src, dict):
+        actions_dict = actions_src
+    else:
+        actions_dict = {}
+
+    def action_value(key: str) -> object:
+        if key in data:
+            return data[key]
+        return actions_dict.get(key)
+
+    skip_analysis = _to_bool(action_value("skip_analysis"))
+    skip_import = _to_bool(action_value("skip_import"), default=False)
+    mark_as_read = _to_bool(action_value("mark_as_read"))
+    archive = _to_bool(action_value("archive"))
+    apply_labels = _normalise_apply_labels(action_value("apply_labels"))
+
+    delete_after_raw = action_value("delete_after_days")
+    delete_after_days: int | None
+    if delete_after_raw in (None, ""):
+        delete_after_days = None
+    else:
+        if isinstance(delete_after_raw, (int, str)):
+            try:
+                delete_after_days = int(delete_after_raw)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    "delete_after_days must be an integer or null"
+                ) from exc
+        else:
+            raise ValueError("delete_after_days must be an integer or null")
+        if delete_after_days < 0:
+            raise ValueError("delete_after_days must be zero or greater")
+
+    if (skip_analysis or skip_import) and not (senders or domains):
+        raise ValueError(
+            "Rules that skip analysis or import must specify senders or domains"
+        )
+
+    name_value = data.get("name") or (
+        senders[0] if senders else (f"@{domains[0]}" if domains else subjects[0])
+    )
+
+    return {
+        "name": str(name_value),
+        "senders": senders,
+        "domains": domains,
+        "subject_contains": subjects,
+        "actions": {
+            "skip_analysis": skip_analysis,
+            "skip_import": skip_import,
+            "mark_as_read": mark_as_read,
+            "apply_labels": apply_labels,
+            "archive": archive,
+            "delete_after_days": delete_after_days,
+        },
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from gmail_automation.cli import (
     save_processed_email_ids,
     process_email,
 )
+from gmail_automation.ignored_rules import IgnoredRulesEngine
 
 
 class TestCLI(unittest.TestCase):
@@ -196,6 +197,7 @@ class TestProcessEmail(unittest.TestCase):
                 "Streaming",
                 True,
                 30,
+                IgnoredRulesEngine.from_config([]),
                 {"Streaming": "label_id"},
                 set(),
                 set(),

--- a/tests/test_cli_ignored_rules.py
+++ b/tests/test_cli_ignored_rules.py
@@ -1,0 +1,174 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gmail_automation.cli import process_email
+from gmail_automation.ignored_rules import IgnoredRulesEngine, normalize_ignored_rules
+
+
+def _make_service():
+    service = Mock()
+    users = Mock()
+    messages = Mock()
+    delete_call = Mock()
+    delete_call.execute = Mock()
+    messages.delete.return_value = delete_call
+    get_call = Mock()
+    get_call.execute.return_value = {"labelIds": []}
+    messages.get.return_value = get_call
+    users.messages.return_value = messages
+    service.users.return_value = users
+    return service, messages
+
+
+@pytest.fixture
+def message_details():
+    return (
+        "Subject",
+        "01/01/2000, 12:00 AM PST",
+        "Sender <skip@example.com>",
+        True,
+    )
+
+
+def _run_process_email(
+    service,
+    ignored_rules,
+    existing_labels,
+    message_details,
+    delete_after_days=None,
+    dry_run=False,
+):
+    current_run = set()
+    processed = set()
+    with patch(
+        "gmail_automation.cli.get_message_details_cached", return_value=message_details
+    ):
+        return (
+            process_email(
+                service,
+                "me",
+                "msg1",
+                message_details[0],
+                message_details[1],
+                message_details[2],
+                message_details[3],
+                "Label",
+                False,
+                delete_after_days,
+                ignored_rules,
+                existing_labels,
+                current_run,
+                processed,
+                {},
+                {},
+                dry_run=dry_run,
+            ),
+            current_run,
+            processed,
+        )
+
+
+def test_ignore_rule_mark_read_apply_labels_archive(caplog, message_details):
+    service, messages = _make_service()
+    rules = normalize_ignored_rules(
+        [
+            {
+                "name": "Ignore",
+                "senders": ["skip@example.com"],
+                "actions": {
+                    "skip_analysis": True,
+                    "skip_import": True,
+                    "mark_as_read": True,
+                    "apply_labels": ["Ignored"],
+                    "archive": True,
+                },
+            }
+        ]
+    )
+    engine = IgnoredRulesEngine.from_config(rules)
+    existing_labels = {"Ignored": "LBL_IGNORED"}
+
+    with (
+        patch("gmail_automation.cli.modify_message") as mock_modify,
+        caplog.at_level("INFO"),
+    ):
+        handled, current_run, processed = _run_process_email(
+            service, engine, existing_labels, message_details
+        )
+
+    assert handled is True
+    mock_modify.assert_called_once()
+    args = mock_modify.call_args[0]
+    assert args[3] == ["LBL_IGNORED"]
+    assert args[4] == ["INBOX"]
+    assert args[5] is True
+    messages.delete.assert_not_called()
+    assert processed == {"msg1"}
+    assert "applied to" in caplog.text
+    assert "applied labels" in caplog.text
+    assert "archived" in caplog.text
+    assert "marked as read" in caplog.text
+    assert "flags: skip_analysis, skip_import" in caplog.text
+
+
+def test_ignore_rule_delete_immediate(caplog, message_details):
+    service, messages = _make_service()
+    rules = normalize_ignored_rules(
+        [
+            {
+                "name": "Delete",
+                "senders": ["skip@example.com"],
+                "actions": {"delete_after_days": 0},
+            }
+        ]
+    )
+    engine = IgnoredRulesEngine.from_config(rules)
+
+    with (
+        patch("gmail_automation.cli.modify_message") as mock_modify,
+        caplog.at_level("INFO"),
+    ):
+        handled, current_run, processed = _run_process_email(
+            service, engine, {}, message_details
+        )
+
+    assert handled is True
+    mock_modify.assert_not_called()
+    messages.delete.assert_called_once()
+    messages.delete.return_value.execute.assert_called_once()
+    assert processed == {"msg1"}
+    assert "delete (immediate)" in caplog.text
+
+
+def test_ignore_rule_delete_after_threshold(caplog):
+    service, messages = _make_service()
+    # Use a recent date to verify no deletion occurs
+    fresh_details = ("Subject", "01/01/2099, 12:00 AM PST", "skip@example.com", True)
+    rules = normalize_ignored_rules(
+        [
+            {
+                "name": "Delete",
+                "senders": ["skip@example.com"],
+                "actions": {"delete_after_days": 30},
+            }
+        ]
+    )
+    engine = IgnoredRulesEngine.from_config(rules)
+
+    with (
+        patch("gmail_automation.cli.modify_message") as mock_modify,
+        caplog.at_level("INFO"),
+    ):
+        handled, current_run, processed = _run_process_email(
+            service,
+            engine,
+            {},
+            fresh_details,
+        )
+
+    assert handled is True
+    mock_modify.assert_not_called()
+    messages.delete.assert_not_called()
+    assert processed == {"msg1"}
+    assert "no pipeline actions" in caplog.text

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,25 @@
+import pytest
+
+from gmail_automation.config import validate_and_normalize_config
+
+
+def test_validate_config_rejects_invalid_ignored_rule():
+    config = {"SENDER_TO_LABELS": {}, "IGNORED_EMAILS": [{"name": "bad"}]}
+    with pytest.raises(ValueError):
+        validate_and_normalize_config(config)
+
+
+def test_validate_config_normalizes_ignored_rules():
+    config = {
+        "SENDER_TO_LABELS": {},
+        "IGNORED_EMAILS": [
+            {
+                "name": "Alerts",
+                "senders": ["alert@example.com"],
+                "actions": {"mark_as_read": True, "archive": True},
+            }
+        ],
+    }
+    normalized = validate_and_normalize_config(config)
+    assert normalized["IGNORED_EMAILS"][0]["actions"]["skip_analysis"] is False
+    assert normalized["IGNORED_EMAILS"][0]["actions"]["archive"] is True

--- a/tests/test_dashboard_ignore_emails.py
+++ b/tests/test_dashboard_ignore_emails.py
@@ -1,8 +1,20 @@
 from scripts.dashboard.analysis import compute_label_differences
+from gmail_automation.ignored_rules import normalize_ignored_rules
 
 
 def test_ignored_emails_excluded_from_diff():
-    cfg = {"SENDER_TO_LABELS": {}, "IGNORED_EMAILS": ["skip@example.com"]}
+    cfg = {
+        "SENDER_TO_LABELS": {},
+        "IGNORED_EMAILS": normalize_ignored_rules(
+            [
+                {
+                    "name": "Skip",
+                    "senders": ["skip@example.com"],
+                    "actions": {"skip_analysis": True, "skip_import": True},
+                }
+            ]
+        ),
+    }
     labels = {
         "SENDER_TO_LABELS": {
             "Foo": [{"emails": ["skip@example.com", "keep@example.com"]}]

--- a/tests/test_dashboard_transforms.py
+++ b/tests/test_dashboard_transforms.py
@@ -2,6 +2,8 @@ from scripts.dashboard.transforms import (
     config_to_table,
     table_to_config,
     rows_to_grouped,
+    ignored_rules_to_rows,
+    rows_to_ignored_rules,
 )
 
 
@@ -61,7 +63,8 @@ def test_table_to_config_sanitizes_types():
                     "emails": ["b@example.com"],
                 },
             ]
-        }
+        },
+        "IGNORED_EMAILS": [],
     }
 
 
@@ -77,3 +80,27 @@ def test_rows_to_grouped_groups_by_label_and_index():
         "L1": {0: ["a@example.com", "b@example.com"], 1: ["c@example.com"]},
         "L2": {0: ["d@example.com"]},
     }
+
+
+def test_ignored_rules_round_trip():
+    cfg = {
+        "IGNORED_EMAILS": [
+            {
+                "name": "Legacy",
+                "senders": ["skip@example.com"],
+                "domains": [],
+                "subject_contains": [],
+                "actions": {
+                    "skip_analysis": True,
+                    "skip_import": True,
+                    "mark_as_read": False,
+                    "apply_labels": [],
+                    "archive": False,
+                    "delete_after_days": None,
+                },
+            }
+        ]
+    }
+    rows = ignored_rules_to_rows(cfg)
+    assert rows[0]["name"] == "Legacy"
+    assert rows_to_ignored_rules(rows) == cfg["IGNORED_EMAILS"]

--- a/tests/test_ignored_rules.py
+++ b/tests/test_ignored_rules.py
@@ -1,0 +1,52 @@
+import pytest
+
+from gmail_automation.ignored_rules import (
+    IgnoredRulesEngine,
+    normalize_ignored_rules,
+)
+
+
+def test_normalize_legacy_string_rule():
+    rules = normalize_ignored_rules(["skip@example.com"])
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["senders"] == ["skip@example.com"]
+    actions = rule["actions"]
+    assert actions["skip_analysis"] is True
+    assert actions["skip_import"] is True
+    assert actions["mark_as_read"] is False
+    assert actions["apply_labels"] == []
+
+
+def test_normalize_invalid_rule_requires_match():
+    with pytest.raises(ValueError):
+        normalize_ignored_rules(
+            [{"name": "invalid", "actions": {"skip_analysis": True}}]
+        )
+
+
+def test_engine_matching_and_flags():
+    config_rules = normalize_ignored_rules(
+        [
+            {
+                "name": "Domain Skip",
+                "domains": ["example.com"],
+                "actions": {"skip_analysis": True, "skip_import": False},
+            },
+            {
+                "name": "Subject Rule",
+                "subject_contains": ["alert"],
+                "actions": {"mark_as_read": True},
+            },
+        ]
+    )
+    engine = IgnoredRulesEngine.from_config(config_rules)
+
+    assert engine.should_skip_analysis("foo@example.com") is True
+    assert engine.should_skip_import("foo@example.com") is False
+
+    matches = list(engine.iter_matches("Foo <foo@example.com>", "Weekly Alert"))
+    assert [rule.name for rule in matches] == ["Domain Skip", "Subject Rule"]
+
+    unmatched = list(engine.iter_matches("bar@other.com", "Hello"))
+    assert unmatched == []


### PR DESCRIPTION
## Summary
- add a dedicated ignored rules engine with validation for richer skip/label/archive/delete actions
- normalize IGNORED_EMAILS in config, surface actions in CLI pipeline, and extend dashboard editing UI
- document the new rule schema and add unit plus end-to-end coverage for each rule action and logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdf134bb1c832fb88b2622ddd491c4