### PR TITLE
Add label filter to SENDER_TO_LABELS editor

### DIFF
--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -282,6 +282,7 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                                 editable=True,
                                 row_deletable=True,
                                 row_selectable="multi",
+                                filter_action="native",
                                 page_size=15,
                                 style_table={"maxHeight": "400px", "overflowY": "auto"},
                                 style_cell={
@@ -423,6 +424,23 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                         },
                     ),
                     html.Div(id="diff-projected", style={"marginTop": "8px"}),
+                ],
+            ),
+            html.Div(
+                style={"marginBottom": "24px"},
+                children=[
+                    html.Label(
+                        "Filter SENDER_TO_LABELS by label",
+                        htmlFor="ddl-stl-label-filter",
+                        style={"display": "block", "fontWeight": "bold"},
+                    ),
+                    dcc.Dropdown(
+                        id="ddl-stl-label-filter",
+                        options=[],
+                        placeholder="Select a label to filter the editor...",
+                        clearable=True,
+                        style={"marginTop": "4px", "maxWidth": "400px"},
+                    ),
                 ],
             ),
             html.Div(

--- a/tests/test_dashboard_label_filter.py
+++ b/tests/test_dashboard_label_filter.py
@@ -1,0 +1,41 @@
+"""Tests for the SENDER_TO_LABELS label filter helpers."""
+
+from scripts.dashboard.callbacks import (
+    _build_label_filter_query,
+    _label_filter_options,
+    _sanitize_label_filter_value,
+)
+
+
+def test_label_filter_options_sorted_and_unique():
+    rows = [
+        {"label": "Work", "email": "a@example.com"},
+        {"label": "Personal", "email": "b@example.com"},
+        {"label": "work", "email": "c@example.com"},
+        {"label": "", "email": "d@example.com"},
+        {"label": None, "email": "e@example.com"},
+    ]
+
+    options = _label_filter_options(rows)
+
+    assert options == [
+        {"label": "Personal", "value": "Personal"},
+        {"label": "Work", "value": "Work"},
+        {"label": "work", "value": "work"},
+    ]
+
+
+def test_label_filter_value_invalidated_when_missing():
+    options = [
+        {"label": "Work", "value": "Work"},
+        {"label": "Personal", "value": "Personal"},
+    ]
+
+    assert _sanitize_label_filter_value(options, "Work") == "Work"
+    assert _sanitize_label_filter_value(options, "Unknown") is None
+
+
+def test_label_filter_query_generation():
+    assert _build_label_filter_query("Work") == '{label} = "Work"'
+    assert _build_label_filter_query(None) == ""
+    assert _build_label_filter_query('Foo "Bar"') == '{label} = "Foo \\"Bar\\""'


### PR DESCRIPTION
## Summary
- add a label filter dropdown below the Differences View so editors can narrow the SENDER_TO_LABELS table
- add callbacks that populate dropdown options, keep selections valid, and drive the table filter state
- cover the helper logic with unit tests for label option extraction and query generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdfd7b8b48832f9a1c8a5c1bf289ab