### PR TITLE
Fix grouped tree remove action

### DIFF
--- a/scripts/dashboard/group_ops.py
+++ b/scripts/dashboard/group_ops.py
@@ -5,6 +5,17 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple
 
 
+def _coerce_group_index(value: Any) -> int:
+    """Coerce a group index value into an integer."""
+
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def merge_selected(
     rows: List[Dict[str, Any]], indices: List[int]
 ) -> List[Dict[str, Any]]:
@@ -62,3 +73,47 @@ def split_selected(
         else:
             first_seen[label] = True
     return result
+
+
+def remove_email_from_group(
+    rows: List[Dict[str, Any]],
+    label: str,
+    group_index: Any,
+    email: str,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Remove the first matching email from the provided rows.
+
+    Args:
+        rows: Current table rows.
+        label: Target label for removal.
+        group_index: Group index associated with the email.
+        email: Email address to remove.
+
+    Returns:
+        Tuple of (updated_rows, removed_flag).
+    """
+
+    target_label = (label or "").strip()
+    target_email = (email or "").strip()
+    target_group = _coerce_group_index(group_index)
+
+    updated: List[Dict[str, Any]] = []
+    removed = False
+
+    for row in rows or []:
+        row_label = (row.get("label") or "").strip()
+        row_email = (row.get("email") or "").strip()
+        row_group = _coerce_group_index(row.get("group_index"))
+
+        if (
+            not removed
+            and row_label == target_label
+            and row_email == target_email
+            and row_group == target_group
+        ):
+            removed = True
+            continue
+
+        updated.append(dict(row))
+
+    return updated, removed

--- a/tests/test_dashboard_group_ops.py
+++ b/tests/test_dashboard_group_ops.py
@@ -1,6 +1,10 @@
 """Tests for dashboard group operations."""
 
-from scripts.dashboard.group_ops import merge_selected, split_selected
+from scripts.dashboard.group_ops import (
+    merge_selected,
+    remove_email_from_group,
+    split_selected,
+)
 
 
 def test_merge_selected_merges_to_lowest_index():
@@ -23,3 +27,34 @@ def test_split_selected_assigns_unique_indices():
     split = split_selected(rows, [0, 1])
     indices = {r["group_index"] for r in split}
     assert indices == {0, 1}
+
+
+def test_remove_email_from_group_detaches_selected_email():
+    rows = [
+        {"label": "Work", "group_index": 0, "email": "keep@example.com"},
+        {"label": "Work", "group_index": 0, "email": "remove@example.com"},
+        {"label": "Personal", "group_index": 1, "email": "friend@example.com"},
+    ]
+
+    updated, removed = remove_email_from_group(rows, "Work", 0, "remove@example.com")
+
+    assert removed is True
+    assert len(updated) == 2
+    assert len(rows) == 3  # original untouched
+    emails = [r["email"] for r in updated]
+    assert "remove@example.com" not in emails
+    assert "keep@example.com" in emails
+    assert "friend@example.com" in emails
+
+
+def test_remove_email_from_group_ignores_non_matching_rows():
+    rows = [
+        {"label": "Work", "group_index": 0, "email": "keep@example.com"},
+        {"label": "Work", "group_index": 0, "email": "remove@example.com"},
+    ]
+
+    updated, removed = remove_email_from_group(rows, "Work", 1, "remove@example.com")
+
+    assert removed is False
+    assert updated == rows
+    assert updated is not rows


### PR DESCRIPTION
## Summary
- enable the grouped tree Remove button to drop the clicked email from the working data and refresh the derived stores
- add a helper in `group_ops` to encapsulate removing a sender from a label group
- extend the group operation tests to cover removal behaviour so other rows remain intact

## Testing
- pytest
- pre-commit run --files scripts/dashboard/group_ops.py scripts/dashboard/callbacks.py tests/test_dashboard_group_ops.py

------
https://chatgpt.com/codex/tasks/task_e_68ce10aa6684832f94c9c68a63e5b3fa