### PR TITLE
Add grouped tree alternative to Differences view

### DIFF
--- a/scripts/dashboard/layout.py
+++ b/scripts/dashboard/layout.py
@@ -376,53 +376,100 @@ def make_layout(stl_rows, analysis, diff, cfg, pending):
                 children=[
                     html.H2("Differences View (Source: config/gmail_labels_data.json)"),
                     html.Div(id="diff-summary", style={"marginBottom": "8px"}),
-                    dash_table.DataTable(
-                        id="tbl-diff",
-                        columns=[
-                            {"name": "label", "id": "label"},
-                            {
-                                "name": "exists_in_target",
-                                "id": "exists_in_target",
-                                "presentation": "markdown",
-                            },
-                            {
-                                "name": "total_in_source",
-                                "id": "total_in_source",
-                                "type": "numeric",
-                            },
-                            {
-                                "name": "missing_count",
-                                "id": "missing_count",
-                                "type": "numeric",
-                            },
-                            {
-                                "name": "coverage",
-                                "id": "coverage",
-                                "presentation": "markdown",
-                            },
-                            {
-                                "name": "missing_emails",
-                                "id": "missing_emails",
-                                "presentation": "markdown",
-                            },
-                            {
-                                "name": "actions",
-                                "id": "actions",
-                                "presentation": "markdown",
-                            },
+                    dcc.RadioItems(
+                        id="diff-view-toggle",
+                        options=[
+                            {"label": "Table", "value": "table"},
+                            {"label": "Grouped Tree", "value": "tree"},
                         ],
-                        data=[],
-                        page_size=15,
-                        markdown_options={"html": True},
-                        style_table={"maxHeight": "400px", "overflowY": "auto"},
-                        style_cell={
-                            "fontFamily": "monospace",
-                            "fontSize": "12px",
-                            "whiteSpace": "normal",
-                            "height": "auto",
-                        },
+                        value="table",
+                        inline=True,
+                        style={"marginBottom": "8px"},
                     ),
-                    html.Div(id="diff-projected", style={"marginTop": "8px"}),
+                    html.Div(
+                        id="diff-table-view",
+                        children=[
+                            dash_table.DataTable(
+                                id="tbl-diff",
+                                columns=[
+                                    {"name": "label", "id": "label"},
+                                    {
+                                        "name": "exists_in_target",
+                                        "id": "exists_in_target",
+                                        "presentation": "markdown",
+                                    },
+                                    {
+                                        "name": "total_in_source",
+                                        "id": "total_in_source",
+                                        "type": "numeric",
+                                    },
+                                    {
+                                        "name": "missing_count",
+                                        "id": "missing_count",
+                                        "type": "numeric",
+                                    },
+                                    {
+                                        "name": "coverage",
+                                        "id": "coverage",
+                                        "presentation": "markdown",
+                                    },
+                                    {
+                                        "name": "missing_emails",
+                                        "id": "missing_emails",
+                                        "presentation": "markdown",
+                                    },
+                                    {
+                                        "name": "actions",
+                                        "id": "actions",
+                                        "presentation": "markdown",
+                                    },
+                                ],
+                                data=[],
+                                page_size=15,
+                                markdown_options={"html": True},
+                                style_table={"maxHeight": "400px", "overflowY": "auto"},
+                                style_cell={
+                                    "fontFamily": "monospace",
+                                    "fontSize": "12px",
+                                    "whiteSpace": "normal",
+                                    "height": "auto",
+                                },
+                            ),
+                            html.Div(id="diff-projected", style={"marginTop": "8px"}),
+                        ],
+                    ),
+                    html.Div(
+                        id="diff-tree-view",
+                        style={"display": "none"},
+                        children=[
+                            html.Div(
+                                [
+                                    "Hover to inspect missing emails by label. ",
+                                    "Click a group to zoom; ",
+                                    "use the root breadcrumb to reset.",
+                                ],
+                                style={
+                                    "fontSize": "12px",
+                                    "color": "#555",
+                                    "marginBottom": "8px",
+                                },
+                            ),
+                            dcc.Graph(
+                                id="diff-tree",
+                                figure={},
+                                style={"height": "420px"},
+                                config={"displayModeBar": False},
+                            ),
+                            html.Div(
+                                id="diff-tree-empty",
+                                style={
+                                    "marginTop": "8px",
+                                    "fontSize": "12px",
+                                    "color": "#a00",
+                                },
+                            ),
+                        ],
+                    ),
                 ],
             ),
             html.Div(

--- a/tests/test_dashboard_diff_tree.py
+++ b/tests/test_dashboard_diff_tree.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dash import dcc
+
+from scripts.dashboard.callbacks import (
+    _build_diff_tree_figure,
+    _prepare_diff_tree_nodes,
+)
+from scripts.dashboard.layout import make_layout
+
+
+def _find_component(component, target_id: str):
+    """Recursively search Dash component children by id."""
+
+    if isinstance(component, (list, tuple)):
+        for child in component:
+            found = _find_component(child, target_id)
+            if found is not None:
+                return found
+        return None
+
+    if getattr(component, "id", None) == target_id:
+        return component
+
+    children = getattr(component, "children", None)
+    if not children:
+        return None
+
+    return _find_component(children, target_id)
+
+
+def test_prepare_diff_tree_nodes_groups_by_status():
+    diff = {
+        "comparison_summary": {"total_missing_emails": 3},
+        "missing_emails_by_label": {
+            "Work": {
+                "label_exists_in_target": True,
+                "missing_emails": ["a@example.com", "b@example.com"],
+                "total_emails_in_source": 4,
+            },
+            "Personal": {
+                "label_exists_in_target": False,
+                "missing_emails": ["c@example.com"],
+                "total_emails_in_source": 1,
+            },
+        },
+    }
+
+    nodes = _prepare_diff_tree_nodes(diff)
+    labels = {n["label"] for n in nodes}
+
+    assert "All Labels" in labels
+    assert "Existing Labels" in labels
+    assert "Missing Labels" in labels
+    assert any(n["parent"] == "Existing Labels" and n["label"] == "Work" for n in nodes)
+    assert any(
+        n["parent"] == "Missing Labels" and n["label"] == "Personal" for n in nodes
+    )
+
+    personal_node = next(n for n in nodes if n["label"] == "Personal")
+    assert "Label missing from config." in personal_node["tooltip"]
+
+
+def test_build_diff_tree_figure_handles_empty_diff():
+    fig = _build_diff_tree_figure(None)
+    assert len(fig.data) == 0
+
+    fig = _build_diff_tree_figure({"missing_emails_by_label": {}})
+    assert len(fig.data) == 0
+
+
+def test_layout_includes_diff_tree_toggle():
+    layout = make_layout([], {}, {}, {}, [])
+    toggle = _find_component(layout, "diff-view-toggle")
+    assert isinstance(toggle, dcc.RadioItems)
+    table_view = _find_component(layout, "diff-table-view")
+    tree_view = _find_component(layout, "diff-tree-view")
+    assert table_view is not None
+    assert tree_view is not None


### PR DESCRIPTION
## Summary
- add helper utilities and callbacks to build a grouped treemap from diff data and toggle it with the existing table view
- extend the dashboard layout with a Differences view switcher and grouped tree container
- add unit tests that validate the grouped tree data, empty-state figure, and layout wiring

## Testing
- pytest
- pre-commit run --files scripts/dashboard/layout.py scripts/dashboard/callbacks.py tests/test_dashboard_diff_tree.py


------
https://chatgpt.com/codex/tasks/task_e_68ce10bbb14c832f8c32220c1fdceaf0