### PR TITLE
Add configurable instant and deferred email deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 data/last_run.txt
 data/processed_email_ids.txt
 data/sender_last_run.json
+data/deferred_deletions.json
 
 # Binary executables
 tools/jq.exe

--- a/config/config-sample/gmail_config.sample.json
+++ b/config/config-sample/gmail_config.sample.json
@@ -11,5 +11,19 @@
                 ]
             }
         ]
-    }
+    },
+    "PROTECTED_LABELS": [
+        "Important"
+    ],
+    "SELECTED_EMAIL_DELETIONS": [
+        {
+            "name": "Delete marketing emails once read",
+            "query": "from:marketing@example.com",
+            "defer_until_read": true,
+            "enabled": true,
+            "protected_labels": [
+                "Keep"
+            ]
+        }
+    ]
 }

--- a/src/gmail_automation/cli.py
+++ b/src/gmail_automation/cli.py
@@ -1,8 +1,9 @@
 import argparse
+import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Optional, Set, Tuple
 
 from dateutil import parser
 from zoneinfo import ZoneInfo
@@ -50,6 +51,11 @@ TZINFOS: dict[str, ZoneInfo] = {
 logger = get_logger(__name__)
 
 
+ConfirmationProvider = Callable[[str, Dict[str, Any]], bool]
+
+DEFERRED_DELETION_FILENAME = "deferred_deletions.json"
+
+
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(description="Gmail automation script")
     parser.add_argument(
@@ -79,6 +85,14 @@ def parse_args(argv=None):
         "--log-file",
         default=None,
         help="Optional path to a log file",
+    )
+    parser.add_argument(
+        "--confirm-delete",
+        action="store_true",
+        help=(
+            "Confirm deletion actions for selected emails "
+            "without an interactive prompt."
+        ),
     )
     parser.add_argument(
         "--version",
@@ -123,6 +137,163 @@ def parse_header(headers, header_name):
     )
 
 
+def get_data_directory() -> str:
+    """Return the repository data directory, ensuring it exists."""
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.abspath(os.path.join(script_dir, os.pardir, os.pardir))
+    data_dir = os.path.join(root_dir, "data")
+    os.makedirs(data_dir, exist_ok=True)
+    return data_dir
+
+
+def get_deferred_deletion_path(data_dir: str) -> str:
+    """Return the absolute path to the deferred deletions state file."""
+
+    return os.path.join(data_dir, DEFERRED_DELETION_FILENAME)
+
+
+def load_deferred_deletions(file_path: str) -> Dict[str, Dict[str, Any]]:
+    """Load persisted deferred deletion requests from disk."""
+
+    if not os.path.exists(file_path):
+        return {}
+    try:
+        with open(file_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        logger.error(
+            "Failed to load deferred deletions from %s: %s",
+            file_path,
+            error,
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(data, dict):
+        logger.error(
+            "Deferred deletion file %s contained invalid structure. Starting fresh.",
+            file_path,
+        )
+        return {}
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for msg_id, metadata in data.items():
+        if isinstance(metadata, dict):
+            normalized[str(msg_id)] = metadata
+        else:
+            logger.warning(
+                "Ignoring malformed deferred deletion entry for %s in %s.",
+                msg_id,
+                file_path,
+            )
+    return normalized
+
+
+def save_deferred_deletions(file_path: str, state: Dict[str, Dict[str, Any]]) -> None:
+    """Persist deferred deletion requests to disk."""
+
+    try:
+        with open(file_path, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2, sort_keys=True)
+    except OSError as error:
+        logger.error(
+            "Failed to persist deferred deletions to %s: %s",
+            file_path,
+            error,
+            exc_info=True,
+        )
+
+
+def build_confirmation_provider(auto_confirm: bool) -> ConfirmationProvider:
+    """Create a confirmation callback honoring the CLI configuration."""
+
+    def provider(message_id: str, context: Dict[str, Any]) -> bool:
+        prompt = context.get("prompt") or context.get("rule_name") or message_id
+        confirmation_message = context.get(
+            "confirmation_message",
+            f"Delete message {message_id} ({prompt})? [y/N]: ",
+        )
+        if auto_confirm:
+            logger.debug(
+                "Auto-confirmation enabled for deletion of %s (rule: %s).",
+                message_id,
+                context.get("rule_name"),
+            )
+            return True
+        try:
+            response = input(confirmation_message)
+        except EOFError:
+            logger.error(
+                "Failed to obtain confirmation for message %s due to EOF.",
+                message_id,
+            )
+            return False
+        if response.strip().lower() in {"y", "yes"}:
+            return True
+        logger.info("User declined deletion for message %s.", message_id)
+        return False
+
+    return provider
+
+
+def is_message_protected(
+    label_ids: Tuple[str, ...] | list[str],
+    global_protected_labels: Tuple[str, ...] | list[str],
+    rule_protected_labels: Tuple[str, ...] | list[str],
+    label_id_to_name: Dict[str, str],
+) -> bool:
+    """Return ``True`` if the message has any protected labels."""
+
+    protected = set(global_protected_labels or []) | set(rule_protected_labels or [])
+    if not protected:
+        return False
+    message_labels = {label for label in label_ids}
+    message_labels.update(label_id_to_name.get(label, label) for label in label_ids)
+    return any(label in protected for label in message_labels)
+
+
+def extract_message_metadata(
+    message_id: str, message: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Extract normalized metadata from a Gmail message resource."""
+
+    if not message or "payload" not in message or "headers" not in message["payload"]:
+        logger.error(f"Invalid message structure for ID {message_id}: {message}")
+        return None
+
+    headers = message["payload"]["headers"]
+    subject = parse_header(headers, "subject")
+    date_str = parse_header(headers, "date")
+    sender = parse_header(headers, "from")
+    details = {"subject": subject, "date": date_str, "sender": sender}
+    validation = validate_details(details, ["subject", "date", "sender"])
+    if validation["missing_details"]:
+        logger.error(
+            "Missing details for message ID %s: %s",
+            message_id,
+            validation["missing_details"],
+        )
+        logger.info(
+            "Available details for message ID %s: %s",
+            message_id,
+            validation["available_details"],
+        )
+        return None
+
+    parsed_date = parse_email_date(date_str or "")
+    formatted_date = (
+        parsed_date.strftime("%m/%d/%Y, %I:%M %p %Z") if parsed_date else None
+    )
+    is_unread = "UNREAD" in message.get("labelIds", [])
+    return {
+        "subject": subject,
+        "formatted_date": formatted_date,
+        "sender": sender,
+        "is_unread": is_unread,
+        "label_ids": message.get("labelIds", []),
+        "raw_date": date_str,
+    }
+
+
 def validate_details(details, expected_keys):
     missing_details = [
         key for key in expected_keys if key not in details or details[key] is None
@@ -138,35 +309,15 @@ def validate_details(details, expected_keys):
 def get_message_details(service, user_id, msg_id):
     try:
         message = service.users().messages().get(userId=user_id, id=msg_id).execute()
-        if (
-            not message
-            or "payload" not in message
-            or "headers" not in message["payload"]
-        ):
-            logger.error(f"Invalid message structure for ID {msg_id}: {message}")
+        metadata = extract_message_metadata(msg_id, message)
+        if metadata is None:
             return None, None, None, None
-        headers = message["payload"]["headers"]
-        subject = parse_header(headers, "subject")
-        date_str = parse_header(headers, "date")
-        sender = parse_header(headers, "from")
-        is_unread = "UNREAD" in message.get("labelIds", [])
-        details = {"subject": subject, "date": date_str, "sender": sender}
-        validation = validate_details(details, ["subject", "date", "sender"])
-        if validation["missing_details"]:
-            logger.error(
-                "Missing details for message ID %s: %s",
-                msg_id,
-                validation["missing_details"],
-            )
-            logger.info(
-                "Available details for message ID %s: %s",
-                msg_id,
-                validation["available_details"],
-            )
-            return None, None, None, None
-        date = parse_email_date(date_str)
-        formatted_date = date.strftime("%m/%d/%Y, %I:%M %p %Z") if date else None
-        return subject, formatted_date, sender, is_unread
+        return (
+            metadata["subject"],
+            metadata["formatted_date"],
+            metadata["sender"],
+            metadata["is_unread"],
+        )
     except Exception as e:
         logger.error(
             f"Error getting message details for ID {msg_id}: {e}",
@@ -448,10 +599,7 @@ def process_emails_for_labeling(
     Returns:
         ``True`` if any emails were processed and modified.
     """
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    root_dir = os.path.abspath(os.path.join(script_dir, os.pardir, os.pardir))
-    data_dir = os.path.join(root_dir, "data")
-    os.makedirs(data_dir, exist_ok=True)
+    data_dir = get_data_directory()
     processed_ids_file = os.path.join(data_dir, "processed_email_ids.txt")
     processed_email_ids = load_processed_email_ids(processed_ids_file)
     current_run_processed_ids: Set[str] = set()
@@ -502,6 +650,311 @@ def process_emails_for_labeling(
     return any_emails_processed
 
 
+def process_selected_email_deletions(
+    service,
+    user_id: str,
+    existing_labels: Dict[str, str],
+    config: Dict[str, Any],
+    data_dir: str,
+    confirmation_provider: ConfirmationProvider,
+    dry_run: bool = False,
+    actor: str = "system",
+) -> bool:
+    """Delete emails selected via configuration rules."""
+
+    rules = config.get("SELECTED_EMAIL_DELETIONS", [])
+    if not rules:
+        return False
+
+    os.makedirs(data_dir, exist_ok=True)
+    deferred_path = get_deferred_deletion_path(data_dir)
+    existing_deferred = load_deferred_deletions(deferred_path)
+    updated_deferred = dict(existing_deferred)
+    state_changed = False
+    any_action = False
+
+    global_protected = config.get("PROTECTED_LABELS", []) or []
+    label_id_to_name = {label_id: name for name, label_id in existing_labels.items()}
+
+    for rule in rules:
+        if not rule.get("enabled", True):
+            logger.info("Skipping disabled deletion rule '%s'.", rule.get("name"))
+            continue
+
+        rule_name = rule.get("name", "Unnamed Rule")
+        message_ids = set(rule.get("message_ids", []))
+        query = rule.get("query")
+        if query:
+            try:
+                messages = fetch_emails_to_label_optimized(service, user_id, query)
+            except HttpError as error:
+                logger.error(
+                    "Failed to fetch messages for deletion rule '%s': %s",
+                    rule_name,
+                    error,
+                    exc_info=True,
+                )
+                continue
+            message_ids.update(message["id"] for message in messages or [])
+
+        if not message_ids:
+            logger.info(
+                "No messages matched deletion rule '%s'.",
+                rule_name,
+            )
+            continue
+
+        for msg_id in sorted(message_ids):
+            try:
+                message = (
+                    service.users().messages().get(userId=user_id, id=msg_id).execute()
+                )
+            except HttpError as error:
+                logger.error(
+                    "Error retrieving message %s for deletion rule '%s': %s",
+                    msg_id,
+                    rule_name,
+                    error,
+                    exc_info=True,
+                )
+                continue
+
+            metadata = extract_message_metadata(msg_id, message)
+            if metadata is None:
+                continue
+
+            if is_message_protected(
+                tuple(metadata.get("label_ids", [])),
+                tuple(global_protected),
+                tuple(rule.get("protected_labels", [])),
+                label_id_to_name,
+            ):
+                logger.info(
+                    "Skipping deletion for message %s due to protected labels "
+                    "(rule '%s').",
+                    msg_id,
+                    rule_name,
+                )
+                continue
+
+            defer_until_read = bool(rule.get("defer_until_read", False))
+            deletion_mode = "deferred" if defer_until_read else "instant"
+
+            if defer_until_read and metadata.get("is_unread"):
+                timestamp = datetime.now(timezone.utc).isoformat()
+                if dry_run:
+                    logger.info(
+                        "Dry run: would defer deletion of message %s for rule '%s' "
+                        "until it is read.",
+                        msg_id,
+                        rule_name,
+                    )
+                else:
+                    updated_deferred[msg_id] = {
+                        "rule_name": rule_name,
+                        "protected_labels": rule.get("protected_labels", []),
+                        "requested_at": timestamp,
+                    }
+                    state_changed = True
+                    logger.info(
+                        "Deferred deletion of message %s for rule '%s' until it "
+                        "is read.",
+                        msg_id,
+                        rule_name,
+                    )
+                any_action = True
+                continue
+
+            prompt_value = f"{metadata.get('sender')} - {metadata.get('subject')}"
+            context = {
+                "rule_name": rule_name,
+                "prompt": prompt_value,
+                "mode": deletion_mode,
+            }
+            if not confirmation_provider(msg_id, context):
+                logger.info(
+                    "Deletion not confirmed for message %s under rule '%s'.",
+                    msg_id,
+                    rule_name,
+                )
+                continue
+
+            timestamp = datetime.now(timezone.utc).isoformat()
+            if dry_run:
+                logger.info(
+                    "Dry run: would delete message %s at %s by %s in %s mode "
+                    "under rule '%s'.",
+                    msg_id,
+                    timestamp,
+                    actor,
+                    deletion_mode,
+                    rule_name,
+                )
+                any_action = True
+                continue
+
+            try:
+                service.users().messages().delete(userId=user_id, id=msg_id).execute()
+                logger.info(
+                    "Deleted message %s at %s by %s in %s mode under rule '%s'.",
+                    msg_id,
+                    timestamp,
+                    actor,
+                    deletion_mode,
+                    rule_name,
+                )
+                any_action = True
+            except HttpError as error:
+                logger.error(
+                    "Failed to delete message %s under rule '%s': %s",
+                    msg_id,
+                    rule_name,
+                    error,
+                    exc_info=True,
+                )
+
+    if not dry_run and state_changed:
+        save_deferred_deletions(deferred_path, updated_deferred)
+
+    return any_action
+
+
+def process_deferred_selected_deletions(
+    service,
+    user_id: str,
+    existing_labels: Dict[str, str],
+    config: Dict[str, Any],
+    data_dir: str,
+    confirmation_provider: ConfirmationProvider,
+    dry_run: bool = False,
+    actor: str = "system",
+) -> bool:
+    """Process deferred deletion requests that are now eligible."""
+
+    os.makedirs(data_dir, exist_ok=True)
+    deferred_path = get_deferred_deletion_path(data_dir)
+    deferred_state = load_deferred_deletions(deferred_path)
+    if not deferred_state:
+        return False
+
+    label_id_to_name = {label_id: name for name, label_id in existing_labels.items()}
+    global_protected = config.get("PROTECTED_LABELS", []) or []
+
+    updated_state = dict(deferred_state)
+    state_changed = False
+    any_action = False
+
+    for msg_id, metadata in deferred_state.items():
+        rule_name = metadata.get("rule_name", "deferred")
+        rule_protected = metadata.get("protected_labels", []) or []
+        try:
+            message = (
+                service.users().messages().get(userId=user_id, id=msg_id).execute()
+            )
+        except HttpError as error:
+            status = getattr(error, "resp", None)
+            status_code = getattr(status, "status", None)
+            if status_code == 404:
+                logger.info(
+                    "Deferred message %s no longer exists; removing from queue.",
+                    msg_id,
+                )
+                if not dry_run:
+                    updated_state.pop(msg_id, None)
+                    state_changed = True
+                any_action = True
+                continue
+            logger.error(
+                "Failed to retrieve deferred message %s: %s",
+                msg_id,
+                error,
+                exc_info=True,
+            )
+            continue
+
+        message_metadata = extract_message_metadata(msg_id, message)
+        if message_metadata is None:
+            continue
+
+        if message_metadata.get("is_unread"):
+            logger.debug(
+                "Message %s remains unread; deferring deletion (rule '%s').",
+                msg_id,
+                rule_name,
+            )
+            continue
+
+        if is_message_protected(
+            tuple(message_metadata.get("label_ids", [])),
+            tuple(global_protected),
+            tuple(rule_protected),
+            label_id_to_name,
+        ):
+            logger.info(
+                "Skipping deferred deletion for message %s due to protected "
+                "labels (rule '%s').",
+                msg_id,
+                rule_name,
+            )
+            continue
+
+        prompt_value = (
+            f"{message_metadata.get('sender')} - " f"{message_metadata.get('subject')}"
+        )
+        context = {
+            "rule_name": rule_name,
+            "prompt": prompt_value,
+            "mode": "deferred",
+        }
+        if not confirmation_provider(msg_id, context):
+            logger.info(
+                "Deferred deletion not confirmed for message %s (rule '%s').",
+                msg_id,
+                rule_name,
+            )
+            continue
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        if dry_run:
+            logger.info(
+                "Dry run: would delete deferred message %s at %s by %s in "
+                "deferred mode (rule '%s').",
+                msg_id,
+                timestamp,
+                actor,
+                rule_name,
+            )
+            any_action = True
+            continue
+
+        try:
+            service.users().messages().delete(userId=user_id, id=msg_id).execute()
+            logger.info(
+                "Deleted deferred message %s at %s by %s in deferred mode "
+                "(rule '%s').",
+                msg_id,
+                timestamp,
+                actor,
+                rule_name,
+            )
+            updated_state.pop(msg_id, None)
+            state_changed = True
+            any_action = True
+        except HttpError as error:
+            logger.error(
+                "Failed to delete deferred message %s (rule '%s'): %s",
+                msg_id,
+                rule_name,
+                error,
+                exc_info=True,
+            )
+
+    if not dry_run and state_changed:
+        save_deferred_deletions(deferred_path, updated_state)
+
+    return any_action
+
+
 def main(argv=None):
     args = parse_args(argv)
     try:
@@ -537,6 +990,20 @@ def main(argv=None):
 
         existing_labels = get_existing_labels_cached(service)
 
+        data_dir = get_data_directory()
+        confirmation_provider = build_confirmation_provider(args.confirm_delete)
+
+        deferred_processed = process_deferred_selected_deletions(
+            service,
+            user_id,
+            existing_labels,
+            config,
+            data_dir,
+            confirmation_provider,
+            dry_run=args.dry_run,
+            actor=user_id,
+        )
+
         emails_processed = process_emails_for_labeling(
             service,
             user_id,
@@ -546,6 +1013,24 @@ def main(argv=None):
             current_time,
             dry_run=args.dry_run,
         )
+
+        selected_deletions_processed = process_selected_email_deletions(
+            service,
+            user_id,
+            existing_labels,
+            config,
+            data_dir,
+            confirmation_provider,
+            dry_run=args.dry_run,
+            actor=user_id,
+        )
+
+        if deferred_processed or selected_deletions_processed:
+            logger.info(
+                "Deletion workflows completed (deferred=%s, selected=%s).",
+                deferred_processed,
+                selected_deletions_processed,
+            )
 
         if not args.dry_run:
             update_sender_last_run_times(last_run_times)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
-"""
-Unit tests for the CLI module
-"""
+"""Unit tests for the CLI module."""
 
+import json
+import os
+import tempfile
 import unittest
 import warnings
 from unittest.mock import patch, MagicMock
@@ -14,6 +15,8 @@ from gmail_automation.cli import (
     load_processed_email_ids,
     save_processed_email_ids,
     process_email,
+    process_selected_email_deletions,
+    process_deferred_selected_deletions,
 )
 
 
@@ -218,6 +221,212 @@ class TestProcessEmail(unittest.TestCase):
             "01/01/2000, 12:00 AM PST",
             30,
         )
+
+
+class TestSelectedEmailDeletions(unittest.TestCase):
+    """Tests for selected email deletion workflows."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.data_dir = self.temp_dir.name
+        self.existing_labels = {"INBOX": "INBOX", "Important": "Label_Important"}
+
+    @staticmethod
+    def _message(unread=True, labels=None):
+        label_ids = (
+            labels if labels is not None else ["INBOX"] + (["UNREAD"] if unread else [])
+        )
+        return {
+            "id": "msg1",
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Subject", "value": "Test Subject"},
+                    {"name": "Date", "value": "Wed, 01 Jan 2023 12:00:00 +0000"},
+                ]
+            },
+            "labelIds": label_ids,
+        }
+
+    def _service_with_messages(self, *message_payloads):
+        service = MagicMock()
+        users = service.users.return_value
+        messages_resource = users.messages.return_value
+        messages_resource.get.return_value.execute = MagicMock(
+            side_effect=list(message_payloads)
+        )
+        messages_resource.delete.return_value.execute.return_value = None
+        return service
+
+    def test_instant_delete_selected_emails(self):
+        service = self._service_with_messages(self._message(unread=False))
+        config = {
+            "SELECTED_EMAIL_DELETIONS": [
+                {
+                    "name": "Immediate",
+                    "message_ids": ["msg1"],
+                    "defer_until_read": False,
+                }
+            ],
+            "PROTECTED_LABELS": [],
+        }
+
+        result = process_selected_email_deletions(
+            service,
+            "me",
+            self.existing_labels,
+            config,
+            self.data_dir,
+            lambda *_args, **_kwargs: True,
+            dry_run=False,
+            actor="tester",
+        )
+
+        self.assertTrue(result)
+        service.users().messages().delete.assert_called_once_with(
+            userId="me", id="msg1"
+        )
+
+    def test_deferred_deletion_processed_after_read(self):
+        unread_message = self._message(unread=True)
+        read_message = self._message(unread=False)
+        service = self._service_with_messages(unread_message, read_message)
+        config = {
+            "SELECTED_EMAIL_DELETIONS": [
+                {"name": "Deferred", "message_ids": ["msg1"], "defer_until_read": True}
+            ],
+            "PROTECTED_LABELS": [],
+        }
+
+        result_defer = process_selected_email_deletions(
+            service,
+            "me",
+            self.existing_labels,
+            config,
+            self.data_dir,
+            lambda *_args, **_kwargs: True,
+            dry_run=False,
+            actor="tester",
+        )
+        self.assertTrue(result_defer)
+
+        deferred_path = os.path.join(self.data_dir, "deferred_deletions.json")
+        self.assertTrue(os.path.exists(deferred_path))
+        with open(deferred_path, "r", encoding="utf-8") as handle:
+            deferred_state = json.load(handle)
+        self.assertIn("msg1", deferred_state)
+
+        result_delete = process_deferred_selected_deletions(
+            service,
+            "me",
+            self.existing_labels,
+            config,
+            self.data_dir,
+            lambda *_args, **_kwargs: True,
+            dry_run=False,
+            actor="tester",
+        )
+        self.assertTrue(result_delete)
+        service.users().messages().delete.assert_called_once_with(
+            userId="me", id="msg1"
+        )
+        with open(deferred_path, "r", encoding="utf-8") as handle:
+            remaining_state = json.load(handle)
+        self.assertNotIn("msg1", remaining_state)
+
+    def test_confirmation_required_for_deletion(self):
+        service = self._service_with_messages(self._message(unread=False))
+        config = {
+            "SELECTED_EMAIL_DELETIONS": [
+                {
+                    "name": "Needs confirmation",
+                    "message_ids": ["msg1"],
+                    "defer_until_read": False,
+                }
+            ],
+            "PROTECTED_LABELS": [],
+        }
+
+        with patch("gmail_automation.cli.logger") as mock_logger:
+            result = process_selected_email_deletions(
+                service,
+                "me",
+                self.existing_labels,
+                config,
+                self.data_dir,
+                lambda *_args, **_kwargs: False,
+                dry_run=False,
+                actor="tester",
+            )
+
+        self.assertFalse(result)
+        service.users().messages().delete.assert_not_called()
+        mock_logger.info.assert_any_call(
+            "Deletion not confirmed for message %s under rule '%s'.",
+            "msg1",
+            "Needs confirmation",
+        )
+
+    def test_dry_run_deletion_logs_without_action(self):
+        service = self._service_with_messages(self._message(unread=False))
+        config = {
+            "SELECTED_EMAIL_DELETIONS": [
+                {"name": "Dry run", "message_ids": ["msg1"], "defer_until_read": False}
+            ],
+            "PROTECTED_LABELS": [],
+        }
+
+        with patch("gmail_automation.cli.logger") as mock_logger:
+            result = process_selected_email_deletions(
+                service,
+                "me",
+                self.existing_labels,
+                config,
+                self.data_dir,
+                lambda *_args, **_kwargs: True,
+                dry_run=True,
+                actor="tester",
+            )
+
+        self.assertTrue(result)
+        service.users().messages().delete.assert_not_called()
+        dry_run_logs = [
+            call for call in mock_logger.info.call_args_list if "Dry run" in str(call)
+        ]
+        self.assertTrue(dry_run_logs)
+
+    def test_protected_labels_prevent_deletion(self):
+        protected_labels = ["Important"]
+        service = self._service_with_messages(
+            self._message(unread=False, labels=["INBOX", "Label_Important"])
+        )
+        config = {
+            "SELECTED_EMAIL_DELETIONS": [
+                {
+                    "name": "Protected",
+                    "message_ids": ["msg1"],
+                    "defer_until_read": False,
+                }
+            ],
+            "PROTECTED_LABELS": protected_labels,
+        }
+
+        result = process_selected_email_deletions(
+            service,
+            "me",
+            self.existing_labels,
+            config,
+            self.data_dir,
+            lambda *_args, **_kwargs: True,
+            dry_run=False,
+            actor="tester",
+        )
+
+        self.assertFalse(result)
+        service.users().messages().delete.assert_not_called()
+        deferred_path = os.path.join(self.data_dir, "deferred_deletions.json")
+        self.assertFalse(os.path.exists(deferred_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add CLI support for selected email deletions with confirmation handling, deferred execution, and deletion logging
- normalize new configuration options, update the sample config, and ensure protected labels are honored
- add unit coverage for instant, deferred, dry-run, confirmation, and protected-label deletion flows

## Testing
- pre-commit run --files .gitignore config/config-sample/gmail_config.sample.json src/gmail_automation/cli.py src/gmail_automation/config.py tests/test_cli.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf2f60731c832fb34a99387fbdf2b0